### PR TITLE
feat(view): Added a `display_mode = "border"` option for table-like display

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,23 @@ With this plugin, you can easily view and edit CSV files within Neovim.
 - Displays the CSV file in a tabular format using virtual text.
 - Dynamically updates the CSV view as you edit, ensuring a seamless editing experience.
 - Asynchronous parsing enables comfortable handling of large CSV files.
+- Supports two display modes:
+  - `highlight`: Highlights the delimiter.
+  - `border`: Displays the delimiter with `│`.
 
-**Note:** The plugin is currently a work in progress (WIP) and only implements basic functionality.
+<table>
+  <tr>
+    <th>display_mode = "highlight"</th>
+    <th>display_mode = "border"</th>
+  </tr>
+    <td>
+      <img src="https://github.com/user-attachments/assets/cb26e430-c3cb-407f-bb80-42c11ba7fa19" />
+    </td>
+    <td>
+      <img src="https://github.com/user-attachments/assets/17e5fc01-9a58-4801-b2a6-3d23ca48e26f" />
+    </td>
+  </tr>
+</table>
 
 ## Requirements
 
@@ -62,8 +77,16 @@ The configuration options are as follows:
   view = {
     --- minimum width of a column
     min_column_width = 5,
+
     --- spacing between columns
     spacing = 2,
+
+    --- The display method of the delimiter
+    --- "highlight" highlights the delimiter
+    --- "border" displays the delimiter with `│`
+    --- see `Features` section of the README.
+    ---@type "highlight" | "border"
+    display_mode = "highlight",
   },
 }
 ```

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -11,8 +11,15 @@ M.defaults = {
   view = {
     --- minimum width of a column
     min_column_width = 5,
+
     --- spacing between columns
     spacing = 2,
+
+    --- The display method of the delimiter
+    --- "highlight" highlights the delimiter
+    --- "border" displays the delimiter with `│`
+    ---@type "highlight" | "border"
+    display_mode = "highlight",
   },
 }
 

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -43,8 +43,14 @@ function CsvView:_align_left(lnum, offset, padding, field, border)
       })
   end
 
-  if border then
-    -- self:_render_border(lnum, offset + field.len, padding)
+  if not border then
+    return
+  end
+
+  -- render border or highlight delimiter
+  if self.opts.view.display_mode == "border" then
+    self:_render_border(lnum, offset + field.len)
+  else
     self:_highlight_delimiter(lnum, offset + field.len)
   end
 end
@@ -64,8 +70,14 @@ function CsvView:_align_right(lnum, offset, padding, field, border)
     })
   end
 
-  if border then
-    -- self:_render_border(lnum, offset + field.len, 0)
+  if not border then
+    return
+  end
+
+  -- render border or highlight delimiter
+  if self.opts.view.display_mode == "border" then
+    self:_render_border(lnum, offset + field.len)
+  else
     self:_highlight_delimiter(lnum, offset + field.len)
   end
 end
@@ -101,10 +113,9 @@ end
 --- render table border
 ---@param lnum integer 1-indexed lnum
 ---@param offset integer 0-indexed byte offset
----@param padding integer
-function CsvView:_render_border(lnum, offset, padding)
+function CsvView:_render_border(lnum, offset)
   self.extmarks[#self.extmarks + 1] = vim.api.nvim_buf_set_extmark(self.bufnr, EXTMARK_NS, lnum - 1, offset, {
-    virt_text = { { string.rep(" ", padding) .. "│", "CsvViewDelimiter" } },
+    virt_text = { { "│", "CsvViewDelimiter" } },
     virt_text_pos = "overlay",
   })
 end


### PR DESCRIPTION
This pull request introduces a new display_mode = "border" option to the view configuration, allowing for a table-like display with borders between columns. The border is rendered using the │ character, providing a clear visual separation between the columns.

<table>
  <tr>
    <th>display_mode = "highlight"(Traditional)</th>
    <th>display_mode = "border"(New)</th>
  </tr>
    <td>
      <img src="https://github.com/user-attachments/assets/cb26e430-c3cb-407f-bb80-42c11ba7fa19" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/17e5fc01-9a58-4801-b2a6-3d23ca48e26f" />
    </td>
  </tr>
</table>



