### PR TITLE
Add `CsvViewToggle` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ After opening a CSV file, use the following commands to interact with the plugin
 
 - `:CsvViewEnable`: Enable CSV view.
 - `:CsvViewDisable`: Disable CSV view.
+- `:CsvViewToggle`: Toggle CSV view.
+
+### Lua API
+
+- `require('csvview').enable()`: Enable CSV view.
+- `require('csvview').disable()`: Disable CSV view.
+- `require('csvview').toggle()`: Toggle CSV view.
+- `require('csvview').is_enabled()`: Check if CSV view is enabled.
 
 ## Highlights
 

--- a/lua/csvview/buffer_event.lua
+++ b/lua/csvview/buffer_event.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+---@class CsvViewBufferEvents
+---@field on_lines fun(event: "lines", bufnr: integer, changedtick: integer, first: integer, last: integer, last_updated: integer, byte_count: integer, deleted_codepoints: integer, deleted_codeunits: integer): boolean | nil Return `true` to detach from buffer events.
+---@field on_reload fun(event: "reload", bufnr: integer) : boolean | nil Return `true` to detach from buffer events.
+
+---Register buffer events. This will attach to the buffer and listen for events.
+---When the buffer is reloaded, the events will be re-registered.
+---@param bufnr integer
+---@param events CsvViewBufferEvents
+function M.register(bufnr, events)
+  -- Re-register events on `:e`
+  vim.b[bufnr].csvview_update_auid = vim.api.nvim_create_autocmd({ "BufReadPost" }, {
+    callback = function()
+      M.register(bufnr, events)
+      events.on_reload("reload", bufnr)
+    end,
+    buffer = bufnr,
+    once = true,
+  })
+
+  -- Attach to buffer
+  vim.api.nvim_buf_attach(bufnr, false, {
+    on_lines = function(...)
+      return events.on_lines(...)
+    end,
+    on_reload = function(...)
+      return events.on_reload(...)
+    end,
+  })
+end
+
+---Unregister buffer events.
+---This will detach from the buffer and stop listening for events.
+---@param bufnr integer
+function M.unregister(bufnr)
+  vim.api.nvim_del_autocmd(vim.b[bufnr].csvview_update_auid)
+  vim.b[bufnr].csvview_update_auid = nil
+end
+
+return M

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -104,6 +104,17 @@ function M.disable(bufnr)
   view.detach(bufnr)
 end
 
+--- toggle csv table view
+---@param bufnr integer?
+function M.toggle(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  if M.is_enabled(bufnr) then
+    M.disable(bufnr)
+  else
+    M.enable(bufnr)
+  end
+end
+
 --- setup
 ---@param opts CsvViewOptions?
 function M.setup(opts)
@@ -114,6 +125,9 @@ function M.setup(opts)
   end, {})
   vim.api.nvim_create_user_command("CsvViewDisable", function()
     M.disable()
+  end, {})
+  vim.api.nvim_create_user_command("CsvViewToggle", function()
+    M.toggle()
   end, {})
 end
 

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -200,7 +200,6 @@ end
 ---@param bufnr integer
 function M.detach(bufnr)
   if not M._views[bufnr] then
-    vim.notify("csvview: not attached for this buffer.")
     return
   end
   M._views[bufnr]:clear()
@@ -213,7 +212,6 @@ end
 ---@param column_max_widths number[]
 function M.update(bufnr, fields, column_max_widths)
   if not M._views[bufnr] then
-    vim.notify("csvview: not attached for this buffer.")
     return
   end
   M._views[bufnr]:update(fields, column_max_widths)


### PR DESCRIPTION
This PR introduces a new feature and refactoring changes to enhance the csvview plugin:

## New Feature: `CsvViewToggle` Command
- Added a new `CsvViewToggle` command that allows users to toggle the CSV view on and off with a single command.
- Updated the Lua API to include:
  - `require('csvview').toggle()`: Toggle CSV view.
  - `require('csvview').is_enabled()`: Check if CSV view is enabled.
