### PR TITLE
feat: ignore comment lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ With this plugin, you can easily view and edit CSV files within Neovim.
 - Displays the CSV/TSV file in a tabular format using virtual text.
 - Dynamically updates the CSV view as you edit, ensuring a seamless editing experience.
 - Asynchronous parsing enables comfortable handling of large CSV files.
+- Can ignore comment lines when displaying the CSV file.
 - Supports two display modes:
   - `highlight`: Highlights the delimiter.
   - `border`: Displays the delimiter with `│`.
-- Customizable delimiter character.
+- Customizable delimiter character and comment prefix.
 
 <table>
   <tr>
@@ -93,6 +94,20 @@ The configuration options are as follows:
       ft = {
         tsv = "\t",
       },
+    },
+
+    --- The comment prefix characters
+    --- If the line starts with one of these characters, it is treated as a comment.
+    --- Comment lines are not displayed in tabular format.
+    --- You can also specify it on the command line.
+    --- e.g:
+    --- :CsvViewEnable comment=#
+    --- @type string[]
+    comments = {
+      -- "#",
+      -- "--",
+      -- "//",
+    },
   },
   view = {
     --- minimum width of a column
@@ -119,9 +134,9 @@ After opening a CSV file, use the following commands to interact with the plugin
 
 ### Commands
 
-- `:CsvViewEnable [delimiter]`: Enable CSV view with the specified delimiter.
+- `:CsvViewEnable [options]`: Enable CSV view with the specified options.
 - `:CsvViewDisable`: Disable CSV view.
-- `:CsvViewToggle [delimiter]`: Toggle CSV view with the specified delimiter.
+- `:CsvViewToggle [options]`: Toggle CSV view with the specified options.
 
 ### Example
 
@@ -131,10 +146,10 @@ To toggle CSV view, use the following command. By default, the delimiter is `,` 
 :CsvViewToggle
 ```
 
-To toggle CSV view with a custom delimiter, use the following command.
+To toggle CSV view with a custom delimiter and comments, use the following command.
 
 ```vim
-:CsvViewToggle \t
+:CsvViewToggle delimiter="," comments="#"
 ```
 
 ### Lua API
@@ -149,6 +164,7 @@ To toggle CSV view with a custom delimiter, use the following command.
 | Group                | Default            | Description         |
 | -------------------- | ------------------ | ------------------- |
 | **CsvViewDelimiter** | link to `Comment`  | used for `,`        |
+| **CsvViewComment**   | link to `Comment`  | used for comment    |
 
 ## License
 

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -28,16 +28,18 @@ M.defaults = {
       },
     },
 
-    --- The comment characters
-    --- You can specify a list of comment characters.
+    --- The comment prefix characters
+    --- If the line starts with one of these characters, it is treated as a comment.
+    --- Comment lines are not displayed in tabular format.
+    --- You can also specify it on the command line.
     --- e.g:
-    ---  comment = {
-    ---    "#",
-    ---    "--",
-    ---    "//",
-    ---  }
+    --- :CsvViewEnable comment=#
     --- @type string[]
-    comments = {},
+    comments = {
+      -- "#",
+      -- "--",
+      -- "//",
+    },
   },
   view = {
     --- minimum width of a column

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -27,6 +27,17 @@ M.defaults = {
         tsv = "\t",
       },
     },
+
+    --- The comment characters
+    --- You can specify a list of comment characters.
+    --- e.g:
+    ---  comment = {
+    ---    "#",
+    ---    "--",
+    ---    "//",
+    ---  }
+    --- @type string[]
+    comments = {},
   },
   view = {
     --- minimum width of a column

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -1,8 +1,8 @@
 local M = {}
 
+local CsvViewMetrics = require("csvview.metrics")
 local buffer_event = require("csvview.buffer_event")
 local config = require("csvview.config")
-local metrics = require("csvview.metrics")
 local view = require("csvview.view")
 
 --- @type integer[]
@@ -28,11 +28,10 @@ function M.enable(bufnr, opts)
   end
   table.insert(enable_buffers, bufnr)
 
-  -- Calculate fields and enable csv table view.
-  local fields = {}
-  metrics.compute_csv_metrics(bufnr, opts, function(f, column_max_widths)
-    fields = f
-    view.attach(bufnr, fields, column_max_widths, opts)
+  -- Calculate metrics and attach view.
+  local metrics = CsvViewMetrics:new(bufnr, opts)
+  metrics:compute_buffer(function()
+    view.attach(bufnr, metrics, opts)
   end)
 
   -- Register buffer events.
@@ -43,28 +42,8 @@ function M.enable(bufnr, opts)
         return true
       end
 
-      -- handle line deletion and addition
-      if last > last_updated then
-        -- when line deleted.
-        for _ = last_updated + 1, last do
-          table.remove(fields, last_updated + 1)
-        end
-      elseif last < last_updated then
-        -- when line added.
-        for i = last + 1, last_updated do
-          table.insert(fields, i, {})
-        end
-      else
-        -- when updated within a line.
-      end
-
       -- Recalculate only the difference.
-      local startlnum = first + 1
-      local endlnum = last_updated
-      metrics.compute_csv_metrics(bufnr, opts, function(f, column_max_widths)
-        fields = f
-        view.update(bufnr, fields, column_max_widths)
-      end, startlnum, endlnum, fields)
+      metrics:update(first, last, last_updated)
     end,
 
     on_reload = function()
@@ -75,9 +54,8 @@ function M.enable(bufnr, opts)
 
       -- Recalculate all fields.
       view.detach(bufnr)
-      metrics.compute_csv_metrics(bufnr, opts, function(f, column_max_widths)
-        fields = f
-        view.attach(bufnr, fields, column_max_widths, opts)
+      metrics:compute_buffer(function()
+        view.attach(bufnr, metrics, opts)
       end)
     end,
   })

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -5,14 +5,11 @@ local buffer_event = require("csvview.buffer_event")
 local config = require("csvview.config")
 local view = require("csvview.view")
 
---- @type integer[]
-local enable_buffers = {}
-
 --- check if csv table view is enabled
 ---@param bufnr integer
 ---@return boolean
 function M.is_enabled(bufnr)
-  return vim.tbl_contains(enable_buffers, bufnr)
+  return view.get(bufnr) ~= nil
 end
 
 --- enable csv table view
@@ -26,7 +23,6 @@ function M.enable(bufnr, opts)
     vim.notify("csvview: already enabled for this buffer.")
     return
   end
-  table.insert(enable_buffers, bufnr)
 
   -- Calculate metrics and attach view.
   local metrics = CsvViewMetrics:new(bufnr, opts)
@@ -68,13 +64,6 @@ function M.disable(bufnr)
   if not M.is_enabled(bufnr) then
     vim.notify("csvview: not enabled for this buffer.")
     return
-  end
-
-  -- Remove buffer from enabled list.
-  for i = #enable_buffers, 1, -1 do
-    if enable_buffers[i] == bufnr then
-      table.remove(enable_buffers, i)
-    end
   end
 
   -- Unregister buffer events and detach view.

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -3,25 +3,22 @@ local EXTMARK_NS = vim.api.nvim_create_namespace("csv_extmark")
 
 --- @class CsvView
 --- @field bufnr integer
---- @field fields CsvFieldMetrics[][]
---- @field column_max_widths integer[]
+--- @field metrics CsvViewMetrics
 --- @field extmarks integer[]
 --- @field opts CsvViewOptions
 local CsvView = {}
 
 --- create new view
 ---@param bufnr integer
----@param fields CsvFieldMetrics[][]
----@param column_max_widths integer[]
+---@param metrics CsvViewMetrics
 ---@param opts CsvViewOptions
 ---@return CsvView
-function CsvView:new(bufnr, fields, column_max_widths, opts)
+function CsvView:new(bufnr, metrics, opts)
   self.__index = self
 
   local obj = {}
   obj.bufnr = bufnr
-  obj.fields = fields
-  obj.column_max_widths = column_max_widths
+  obj.metrics = metrics
   obj.extmarks = {}
   obj.opts = opts
   return setmetatable(obj, self)
@@ -31,7 +28,7 @@ end
 ---@param lnum integer 1-indexed lnum
 ---@param offset integer 0-indexed byte offset
 ---@param padding integer
----@param field CsvFieldMetrics
+---@param field CsvFieldMetrics.Field
 ---@param border boolean
 function CsvView:_align_left(lnum, offset, padding, field, border)
   if padding > 0 then
@@ -59,7 +56,7 @@ end
 ---@param lnum integer 1-indexed lnum
 ---@param offset integer 0-indexed byte offset
 ---@param padding integer
----@param field CsvFieldMetrics
+---@param field CsvFieldMetrics.Field
 ---@param border boolean
 function CsvView:_align_right(lnum, offset, padding, field, border)
   if padding > 0 then
@@ -86,11 +83,11 @@ end
 ---@param lnum integer 1-indexed lnum.render header above this line.
 function CsvView:render_column_index_header(lnum)
   local virt = {} --- @type string[][]
-  for i, width in ipairs(self.column_max_widths) do
+  for i, column in ipairs(self.metrics.columns) do
     local char = tostring(i)
-    virt[#virt + 1] = { string.rep(" ", width - #char) }
+    virt[#virt + 1] = { string.rep(" ", column.max_width - #char) }
     virt[#virt + 1] = { char }
-    if i < #self.column_max_widths then
+    if i < #self.metrics.columns then
       virt[#virt + 1] = { "," }
     end
   end
@@ -131,16 +128,17 @@ end
 --- render column
 ---@param lnum integer 1-indexed lnum
 ---@param column_index 1-indexed column index
----@param field CsvFieldMetrics
+---@param field CsvFieldMetrics.Field
 ---@param offset integer 0-indexed byte offset
 function CsvView:render_column(lnum, column_index, field, offset)
-  if not self.column_max_widths[column_index] then
-    -- column_max_widths is not computed yet.
+  if not self.metrics.columns[column_index] then
+    -- not computed yet.
     return
   end
+
   -- if column is last, do not render border.
-  local render_border = column_index < #self.fields[lnum]
-  local colwidth = math.max(self.column_max_widths[column_index], self.opts.view.min_column_width)
+  local render_border = column_index < #self.metrics.rows[lnum].fields
+  local colwidth = math.max(self.metrics.columns[column_index].max_width, self.opts.view.min_column_width)
   local padding = colwidth - field.display_width + self.opts.view.spacing
   if field.is_number then
     self:_align_right(lnum, offset, padding, field, render_border)
@@ -157,13 +155,13 @@ function CsvView:render(top_lnum, bot_lnum)
 
   --- render all fields in ranges
   for lnum = top_lnum, bot_lnum do
-    local line = self.fields[lnum]
+    local line = self.metrics.rows[lnum]
     if not line then
       goto continue
     end
 
     local offset = 0
-    for column_index, field in ipairs(line) do
+    for column_index, field in ipairs(line.fields) do
       self:render_column(lnum, column_index, field, offset)
       offset = offset + field.len + 1
     end
@@ -171,28 +169,19 @@ function CsvView:render(top_lnum, bot_lnum)
   end
 end
 
---- update item
----@param fields CsvFieldMetrics[][]
----@param column_max_widths integer[]
-function CsvView:update(fields, column_max_widths)
-  self.fields = fields
-  self.column_max_widths = column_max_widths
-end
-
 --- @type CsvView[]
 M._views = {}
 
 --- attach view for buffer
 ---@param bufnr integer
----@param fields CsvFieldMetrics[][] }
----@param column_max_widths number[]
+---@param metrics CsvViewMetrics
 ---@param opts CsvViewOptions
-function M.attach(bufnr, fields, column_max_widths, opts)
+function M.attach(bufnr, metrics, opts)
   if M._views[bufnr] then
     vim.notify("csvview: already attached for this buffer.")
     return
   end
-  M._views[bufnr] = CsvView:new(bufnr, fields, column_max_widths, opts)
+  M._views[bufnr] = CsvView:new(bufnr, metrics, opts)
   vim.cmd([[redraw!]])
 end
 
@@ -204,18 +193,6 @@ function M.detach(bufnr)
   end
   M._views[bufnr]:clear()
   M._views[bufnr] = nil
-end
-
---- start render
----@param bufnr integer
----@param fields CsvFieldMetrics[][] }
----@param column_max_widths number[]
-function M.update(bufnr, fields, column_max_widths)
-  if not M._views[bufnr] then
-    return
-  end
-  M._views[bufnr]:update(fields, column_max_widths)
-  vim.cmd([[redraw!]])
 end
 
 --- setup view
@@ -247,8 +224,7 @@ function M.setup()
       if not ok then
         vim.notify(string.format("csvview: error while rendering: %s", result), vim.log.levels.ERROR)
         view:clear()
-        view.column_max_widths = {}
-        view.fields = {}
+        view.metrics:clear()
       end
 
       return false

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -1,11 +1,12 @@
 local EXTMARK_NS = vim.api.nvim_create_namespace("csv_extmark")
 
 --- Get end column of line
+---@param winid integer window id
 ---@param lnum integer 1-indexed lnum
 ---@return integer 0-indexed column
-local function end_col(lnum)
+local function end_col(winid, lnum)
   ---@diagnostic disable-next-line: assign-type-mismatch
-  return vim.fn.col({ lnum, "$" }) - 1
+  return vim.fn.col({ lnum, "$" }, winid) - 1
 end
 
 --- @class CsvView
@@ -157,7 +158,8 @@ end
 --- render
 ---@param top_lnum integer 1-indexed
 ---@param bot_lnum integer 1-indexed
-function CsvView:render(top_lnum, bot_lnum)
+---@param winid integer window id
+function CsvView:render(top_lnum, bot_lnum, winid)
   -- self:render_column_index_header(top_lnum)
 
   --- render all fields in ranges
@@ -171,7 +173,7 @@ function CsvView:render(top_lnum, bot_lnum)
       -- highlight comment line
       self.extmarks[#self.extmarks + 1] = vim.api.nvim_buf_set_extmark(self.bufnr, EXTMARK_NS, lnum - 1, 0, {
         hl_group = "CsvViewComment",
-        end_col = end_col(lnum),
+        end_col = end_col(winid, lnum),
       })
       goto continue
     end
@@ -251,7 +253,7 @@ function M.setup()
       -- render with current window range.
       local top = vim.fn.line("w0", winid)
       local bot = vim.fn.line("w$", winid)
-      local ok, result = pcall(view.render, view, top, bot)
+      local ok, result = pcall(view.render, view, top, bot, winid)
       if not ok then
         vim.notify(string.format("csvview: error while rendering: %s", result), vim.log.levels.ERROR)
         M.detach(bufnr)

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -1,18 +1,50 @@
 local csvview = require("csvview")
 
---- unescape delimiter
----@param delimiter string | nil
----@return string | nil
-local function unescape(delimiter)
-  if delimiter == nil or delimiter == "" then
-    return nil
-  end
+local opts_keys = {
+  "delimiter",
+  "comment",
+}
 
+--- unescape delimiter
+---@param value string
+---@return string
+local function unescape(value)
   return (
-    delimiter
+    value
       :gsub("\\t", "\t") -- tab
       :gsub("\\ ", " ") -- space
-      :sub(1, 1) -- only first character
+  )
+end
+
+--- Parse options from command line
+---@param args string
+---@return {key: string, value: string}[]
+local function parse_cmdline_opts(args)
+  local P = vim.lpeg.P
+  local Cg = vim.lpeg.Cg
+  local Ct = vim.lpeg.Ct
+  local space = P(" ")
+  local escaped_space = P("\\ ")
+  local kv_sep = P("=")
+
+  -- define key=value pair
+  local key = Cg((1 - (space + kv_sep)) ^ 1, "key")
+  local value = Cg((escaped_space + (1 - space)) ^ 1, "value")
+  local pair = Ct(key * kv_sep * value)
+  local pattern = Ct(pair * (space * pair) ^ 0)
+
+  --- @type {key: string, value: string}[]
+  local options = pattern:match(args) or {}
+  return vim.tbl_map(
+    ---@param matched {key: string, value: string}
+    ---@return {key: string, value: string}
+    function(matched)
+      return {
+        key = matched.key,
+        value = unescape(matched.value),
+      }
+    end,
+    options
   )
 end
 
@@ -20,21 +52,63 @@ end
 ---@param args string
 ---@return CsvViewOptions
 local function opts_for_command(args)
-  local delimiter = unescape(args)
-  return {
-    parser = {
-      delimiter = delimiter,
-    },
-  }
+  ---@type CsvViewOptions
+  local opts = { parser = {}, view = {} }
+  local cmdline_opts = parse_cmdline_opts(args)
+  for _, opt in ipairs(cmdline_opts) do
+    if opt.key == "delimiter" then
+      opts.parser.delimiter = opt.value
+    elseif opt.key == "comment" then
+      opts.parser.comments = { opt.value }
+    end
+  end
+
+  vim.print(opts)
+
+  return opts
+end
+
+--- Complete options for CsvView commands
+---@param arg_lead string
+---@param cmd_line string
+---@param cursor_pos integer
+---@return string[]
+local function opts_complete(arg_lead, cmd_line, cursor_pos)
+  -- print(arg_lead, cmd_line, cursor_pos)
+  local opts_candidates = vim.tbl_map(
+    ---@param v string
+    ---@return string
+    function(v)
+      return v .. "="
+    end,
+    opts_keys
+  )
+
+  --- Check if the command line already has the key
+  ---@param key string
+  ---@return boolean
+  local function already_has_opts(key)
+    return string.find(cmd_line, key, 1, true) ~= nil and not vim.endswith(cmd_line, key)
+  end
+
+  return vim.tbl_filter(
+    ---@param v string
+    ---@return string
+    function(v)
+      return vim.startswith(v, arg_lead) and not already_has_opts(v)
+    end,
+    opts_candidates
+  )
 end
 
 vim.api.nvim_create_user_command("CsvViewEnable", function(opts)
-  -- args: delimiter (optional)
   local bufnr = vim.api.nvim_get_current_buf()
-  csvview.enable(bufnr, opts_for_command(opts.args))
+  local cmdopts = opts_for_command(opts.args)
+  csvview.enable(bufnr, cmdopts)
 end, {
   desc = "[csvview] Enable csvview",
   nargs = "?",
+  complete = opts_complete,
 })
 
 vim.api.nvim_create_user_command("CsvViewDisable", function()
@@ -44,10 +118,11 @@ end, {
 })
 
 vim.api.nvim_create_user_command("CsvViewToggle", function(opts)
-  -- args: delimiter (optional)
   local bufnr = vim.api.nvim_get_current_buf()
-  csvview.toggle(bufnr, opts_for_command(opts.args))
+  local cmdopts = opts_for_command(opts.args)
+  csvview.toggle(bufnr, cmdopts)
 end, {
   desc = "[csvview] Toggle csvview",
   nargs = "?",
+  complete = opts_complete,
 })

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -62,9 +62,6 @@ local function opts_for_command(args)
       opts.parser.comments = { opt.value }
     end
   end
-
-  vim.print(opts)
-
   return opts
 end
 


### PR DESCRIPTION
This PR introduces two major updates:

## Ignore Comment Lines Feature
Adds the ability to ignore lines that start with specific prefixes, treating them as comments. Users can specify comment prefixes either through configuration or directly in commands.

### Command Usage:
Allows setting comment prefixes directly in the command line.

#### Example (Command):

```vim
:CsvViewEnable comment=#
```
This command treats lines beginning with # as comments when enabling the view.


### Configuration Table
The config table accepts a comments option to define comment prefixes.

#### Example (Configuration):

```lua
require("csvview").setup({
    parser = {
        comments = { "#", "//" }
    }
})
```
In this setup, lines starting with # or // are treated as comments and are ignored.


#### Codebase Refactoring
Minor refactoring to improve readability and maintainability.