### PR TITLE
Allow customization of the "quote_char"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ The configuration options are as follows:
       },
     },
 
+    --- The quote character
+    --- If a field is enclosed in this character, it is treated as a single field and the delimiter in it will be ignored.
+    --- e.g:
+    ---  quote_char= "'"
+    --- You can also specify it on the command line.
+    --- e.g:
+    --- :CsvViewEnable quote_char='
+    --- @type string
+    quote_char = "\"",
+
     --- The comment prefix characters
     --- If the line starts with one of these characters, it is treated as a comment.
     --- Comment lines are not displayed in tabular format.
@@ -146,10 +156,10 @@ To toggle CSV view, use the following command. By default, the delimiter is `,` 
 :CsvViewToggle
 ```
 
-To toggle CSV view with a custom delimiter and comment, use the following command.
+To toggle CSV view with a custom field delimiter, a custom string delimiter and comment, use the following command.
 
 ```vim
-:CsvViewToggle delimiter=, comment=#
+:CsvViewToggle delimiter=, quote_char=' comment=#
 ```
 
 ### Lua API

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -28,6 +28,16 @@ M.defaults = {
       },
     },
 
+    --- The quote character
+    --- If a field is enclosed in this character, it is treated as a single field and the delimiter in it will be ignored.
+    --- e.g:
+    ---  quote_char= "'"
+    --- You can also specify it on the command line.
+    --- e.g:
+    --- :CsvViewEnable quote_char='
+    --- @type string
+    quote_char = "\"",
+
     --- The comment prefix characters
     --- If the line starts with one of these characters, it is treated as a comment.
     --- Comment lines are not displayed in tabular format.

--- a/lua/csvview/parser.lua
+++ b/lua/csvview/parser.lua
@@ -1,8 +1,5 @@
 local M = {}
 
-local DQUOTE = string.byte('"')
-local SQUOTE = string.byte("'")
-
 --- Find the next character in a string.
 ---@param s string
 ---@param start_pos integer start position
@@ -56,11 +53,29 @@ local function delim_byte(bufnr, opts)
   return char:byte()
 end
 
+--- Get quote char character
+---@param bufnr integer
+---@param opts CsvViewOptions
+---@return integer
+local function quote_char_byte(bufnr, opts)
+  local delim = opts.parser.quote_char
+  ---@diagnostic disable-next-line: no-unknown
+  local char
+  if type(delim) == "string" then
+    char = delim
+  end
+
+  assert(type(char) == "string", string.format("quote char must be a string, got %s", type(char)))
+  assert(#char == 1, string.format("quote char must be a single character, got %s", char))
+  return char:byte()
+end
+
 --- parse line
 ---@param line string
 ---@param delim integer
+---@param quote_char integer
 ---@return string[]
-function M._parse_line(line, delim)
+function M._parse_line(line, delim, quote_char)
   local len = #line
   if len == 0 then
     return {}
@@ -76,7 +91,7 @@ function M._parse_line(line, delim)
       -- add field (even if empty).
       fields[#fields + 1] = string.sub(line, field_start_pos, pos - 1)
       field_start_pos = pos + 1
-    elseif char == DQUOTE or char == SQUOTE then
+    elseif quote_char and char == quote_char then
       -- find closing quote and skip it.
       -- if there is no closing quote, skip the rest of the line.
       local close_pos = find_char(line, pos + 1, char)
@@ -98,10 +113,11 @@ end
 ---@param bufnr integer
 ---@param lnum integer
 ---@param delim integer
+---@param quote_char integer
 ---@return string[]
-function M.get_fields(bufnr, lnum, delim)
+function M.get_fields(bufnr, lnum, delim, quote_char)
   local line = vim.api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, true)
-  return M._parse_line(line[1], delim)
+  return M._parse_line(line[1], delim, quote_char)
 end
 
 --- iterate fields async
@@ -115,6 +131,7 @@ function M.iter_lines_async(bufnr, startlnum, endlnum, cb, opts)
   endlnum = endlnum or vim.api.nvim_buf_line_count(bufnr)
 
   local delim = delim_byte(bufnr, opts)
+  local quote_char = quote_char_byte(bufnr, opts)
   local iter_num = (endlnum - startlnum) / opts.parser.async_chunksize
   local start_time = vim.uv.now()
   if iter_num > 500 then
@@ -132,7 +149,7 @@ function M.iter_lines_async(bufnr, startlnum, endlnum, cb, opts)
       if is_comment_line(line, opts) then
         cb.on_line(i, true, {})
       else
-        cb.on_line(i, false, M._parse_line(line, delim))
+        cb.on_line(i, false, M._parse_line(line, delim, quote_char))
       end
     end
 

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -2,6 +2,7 @@ local csvview = require("csvview")
 
 local opts_keys = {
   "delimiter",
+  "quote_char",
   "comment",
 }
 
@@ -58,6 +59,8 @@ local function opts_for_command(args)
   for _, opt in ipairs(cmdline_opts) do
     if opt.key == "delimiter" then
       opts.parser.delimiter = opt.value
+    elseif opt.key == "quote_char" then
+      opts.parser.quote_char = opt.value
     elseif opt.key == "comment" then
       opts.parser.comments = { opt.value }
     end


### PR DESCRIPTION
Currently, csvview.nvim uses both " and ' as quote chars. This causes problems with some files, where for instance the ' char is used in the language (e.g. "It's a nice day to be alive!").

Changes the behavior of csvview.nvim to use the " as quote char by default, but allows the user to specify another quote char in the options (but in the configuration and as a parameter to the CsvView... commands).