### PR TITLE
perf(metrics): Improve Performance for Inserting/Deleting Large Numbers of Lines in Buffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination reposito
       - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,7 +27,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "style(format): fix code style"
-          branch: ${{ github.head_ref }}
+          branch: ${{ github.ref }}
       - uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/lua/csvview/metrics.lua
+++ b/lua/csvview/metrics.lua
@@ -254,20 +254,28 @@ function CsvViewMetrics:_ensure_column(col_idx)
 end
 
 --- Add row placeholders
----@param prev_last integer
+---@param start integer
 ---@param num integer
-function CsvViewMetrics:_add_row_placeholders(prev_last, num)
-  for _ = 1, num do
-    table.insert(self.rows, prev_last + 1, { fields = {} })
+function CsvViewMetrics:_add_row_placeholders(start, num)
+  -- `table.insert` is inefficient when editing large buffers
+  local len = #self.rows
+  for i = 0, num - 1 do
+    self.rows[len + num - i] = self.rows[len - i]
+  end
+  for i = start, start + num - 1 do
+    self.rows[i] = { fields = {} }
   end
 end
 
 --- Remove rows
----@param last integer
+---@param start integer
 ---@param num integer
-function CsvViewMetrics:_remove_rows(last, num)
-  for _ = 1, num do
-    table.remove(self.rows, last + 1)
+function CsvViewMetrics:_remove_rows(start, num)
+  -- `table.remove` is inefficient when editing large buffers
+  local len = #self.rows
+  for i = start, len do
+    self.rows[i] = self.rows[i + num]
+    self.rows[i + num] = nil
   end
 end
 

--- a/lua/csvview/metrics.lua
+++ b/lua/csvview/metrics.lua
@@ -80,9 +80,9 @@ function CsvViewMetrics:update(first, prev_last, last, on_end)
   -- print("update", first, prev_last, last)
   local delta = last - prev_last
   if delta > 0 then
-    self:_add_row_placeholders(prev_last, delta)
+    self:_add_row_placeholders(prev_last + 1, delta)
   elseif delta < 0 then
-    self:_remove_rows(last, math.abs(delta))
+    self:_remove_rows(last + 1, math.abs(delta))
     self:_mark_recalculation_on_delete(prev_last, last, recalculate_columns)
   end
 
@@ -259,8 +259,8 @@ end
 function CsvViewMetrics:_add_row_placeholders(start, num)
   -- `table.insert` is inefficient when editing large buffers
   local len = #self.rows
-  for i = 0, num - 1 do
-    self.rows[len + num - i] = self.rows[len - i]
+  for i = len, start, -1 do
+    self.rows[i + num] = self.rows[i]
   end
   for i = start, start + num - 1 do
     self.rows[i] = { fields = {} }

--- a/tests/cases/buffer_update.lua
+++ b/tests/cases/buffer_update.lua
@@ -156,6 +156,52 @@ return {
         },
       },
       {
+        name = "renders correctly when a new line is added and it is the first line",
+        lines = {
+          "1,XUMMW7737A,Jane Davis,jane.williams@example.org,1964-03-22",
+          "2,CFLFGKJX4M,John Martinez,emily.davis@example.org,1986-12-28",
+          "3,PHZ9SYAJ23,Alex Davis,jane.brown@example.org,1976-11-06",
+          "4,NS8EQ0MR1A,Jane Martinez,katie.garcia@example.org,2000-10-18",
+        },
+        changes = {
+          {
+            type = "insert",
+            line = 1,
+            after = "Index,ID,Name,Email,Birthday",
+          },
+        },
+        expected = {
+          "Index  ,ID          ,Name           ,Email                      ,Birthday    ",
+          "      1,XUMMW7737A  ,Jane Davis     ,jane.williams@example.org  ,1964-03-22  ",
+          "      2,CFLFGKJX4M  ,John Martinez  ,emily.davis@example.org    ,1986-12-28  ",
+          "      3,PHZ9SYAJ23  ,Alex Davis     ,jane.brown@example.org     ,1976-11-06  ",
+          "      4,NS8EQ0MR1A  ,Jane Martinez  ,katie.garcia@example.org   ,2000-10-18  ",
+        },
+      },
+      {
+        name = "renders correctly when a new line is added and it is the last line",
+        lines = {
+          "Index,ID,Name,Email,Birthday",
+          "1,XUMMW7737A,Jane Davis,jane.williams@example.org,1964-03-22",
+          "2,CFLFGKJX4M,John Martinez,emily.davis@example.org,1986-12-28",
+          "3,PHZ9SYAJ23,Alex Davis,jane.brown@example.org,1976-11-06",
+        },
+        changes = {
+          {
+            type = "insert",
+            line = 5,
+            after = "4,NS8EQ0MR1A,Jane Martinez,katie.garcia@example.org,2000-10-18",
+          },
+        },
+        expected = {
+          "Index  ,ID          ,Name           ,Email                      ,Birthday    ",
+          "      1,XUMMW7737A  ,Jane Davis     ,jane.williams@example.org  ,1964-03-22  ",
+          "      2,CFLFGKJX4M  ,John Martinez  ,emily.davis@example.org    ,1986-12-28  ",
+          "      3,PHZ9SYAJ23  ,Alex Davis     ,jane.brown@example.org     ,1976-11-06  ",
+          "      4,NS8EQ0MR1A  ,Jane Martinez  ,katie.garcia@example.org   ,2000-10-18  ",
+        },
+      },
+      {
         name = "renders correctly when a line is removed and column width shrinks",
         lines = {
           "Index,ID,Name,Email,Birthday",
@@ -173,6 +219,46 @@ return {
           "      2,CFLFGKJX4M  ,John Martinez  ,emily.davis@example.org   ,1986-12-28  ",
           "      3,PHZ9SYAJ23  ,Alex Davis     ,jane.brown@example.org    ,1976-11-06  ",
           "      4,NS8EQ0MR1A  ,Jane Martinez  ,katie.garcia@example.org  ,2000-10-18  ",
+        },
+      },
+      {
+        name = "renders correctly when a line is removed and it is the first line",
+        lines = {
+          "Index,ID,Name,Email,Birthday",
+          "1,XUMMW7737A,Jane Davis,jane.williams@example.org,1964-03-22",
+          "2,CFLFGKJX4M,John Martinez,emily.davis@example.org,1986-12-28",
+          "3,PHZ9SYAJ23,Alex Davis,jane.brown@example.org,1976-11-06",
+          "4,NS8EQ0MR1A,Jane Martinez,katie.garcia@example.org,2000-10-18",
+        },
+        changes = { {
+          type = "delete",
+          line = 1,
+        } },
+        expected = {
+          "      1,XUMMW7737A  ,Jane Davis     ,jane.williams@example.org  ,1964-03-22  ",
+          "      2,CFLFGKJX4M  ,John Martinez  ,emily.davis@example.org    ,1986-12-28  ",
+          "      3,PHZ9SYAJ23  ,Alex Davis     ,jane.brown@example.org     ,1976-11-06  ",
+          "      4,NS8EQ0MR1A  ,Jane Martinez  ,katie.garcia@example.org   ,2000-10-18  ",
+        },
+      },
+      {
+        name = "renders correctly when a line is removed and it is the last line",
+        lines = {
+          "Index,ID,Name,Email,Birthday",
+          "1,XUMMW7737A,Jane Davis,jane.williams@example.org,1964-03-22",
+          "2,CFLFGKJX4M,John Martinez,emily.davis@example.org,1986-12-28",
+          "3,PHZ9SYAJ23,Alex Davis,jane.brown@example.org,1976-11-06",
+          "4,NS8EQ0MR1A,Jane Martinez,katie.garcia@example.org,2000-10-18",
+        },
+        changes = { {
+          type = "delete",
+          line = 5,
+        } },
+        expected = {
+          "Index  ,ID          ,Name           ,Email                      ,Birthday    ",
+          "      1,XUMMW7737A  ,Jane Davis     ,jane.williams@example.org  ,1964-03-22  ",
+          "      2,CFLFGKJX4M  ,John Martinez  ,emily.davis@example.org    ,1986-12-28  ",
+          "      3,PHZ9SYAJ23  ,Alex Davis     ,jane.brown@example.org     ,1976-11-06  ",
         },
       },
       {


### PR DESCRIPTION
## Overview
This PR improves the performance of handling large numbers of rows in buffers by refactoring the `CsvViewMetrics:_add_row_placeholders` and `CsvViewMetrics:_remove_rows` methods. The changes address inefficiencies in `table.insert` and `table.remove`, which are not ideal for large datasets due to their linear complexity.

## Changes
- **Optimized `CsvViewMetrics:_add_row_placeholders`**  
  Replaced `table.insert` with a custom method that shifts elements directly. This approach significantly improves insertion performance for large buffers.
  
- **Optimized `CsvViewMetrics:_remove_rows`**  
  Replaced `table.remove` with a direct element-shifting method, enhancing efficiency when removing multiple rows.

## Performance Improvements
In testing, the time required to insert or delete 100,000 rows decreased significantly—from approximately 5 seconds to just over 1 second. This represents a substantial reduction in latency for large-scale edits.
