### PR TITLE
fix(#23): improve buffer detach handling

### DIFF
--- a/lua/csvview/keymap.lua
+++ b/lua/csvview/keymap.lua
@@ -70,7 +70,7 @@ function M.unregister(opts)
   for _, map in pairs(keymaps) do
     local lhs = map[1]
     local mode = map.mode
-    vim.keymap.del(mode, lhs, { buffer = true })
+    pcall(vim.keymap.del, mode, lhs, { buffer = true })
   end
 end
 


### PR DESCRIPTION
- Refactored buffer detach handling to ensure proper cleanup.
- Added autocmd to disable csvview when buffer is unloaded.
- Improved keymap unregistration with pcall for safety.

Fixes #23 