### PR TITLE
feat: Support bufnr=0 for csvview API

### DIFF
--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -15,6 +15,7 @@ local keymap = require("csvview.keymap")
 ---@param bufnr integer
 ---@return boolean
 function M.is_enabled(bufnr)
+  bufnr = buf.resolve_bufnr(bufnr)
   return get_view(bufnr) ~= nil
 end
 
@@ -22,7 +23,7 @@ end
 ---@param bufnr integer?
 ---@param opts CsvView.Options?
 function M.enable(bufnr, opts)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  bufnr = buf.resolve_bufnr(bufnr)
   opts = config.get(opts) ---@diagnostic disable-line: cast-local-type
 
   if M.is_enabled(bufnr) then
@@ -88,7 +89,7 @@ end
 --- disable csv table view
 ---@param bufnr integer?
 function M.disable(bufnr)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  bufnr = buf.resolve_bufnr(bufnr)
   if not M.is_enabled(bufnr) then
     vim.notify("csvview: not enabled for this buffer.")
     return
@@ -101,7 +102,7 @@ end
 ---@param bufnr integer?
 ---@param opts CsvView.Options?
 function M.toggle(bufnr, opts)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  bufnr = buf.resolve_bufnr(bufnr)
   if M.is_enabled(bufnr) then
     M.disable(bufnr)
   else

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -1,4 +1,5 @@
 local EXTMARK_NS = vim.api.nvim_create_namespace("csv_extmark")
+local buf = require("csvview.buf")
 local errors = require("csvview.errors")
 
 --- Get end column of line
@@ -241,6 +242,7 @@ M._views = {}
 ---@param bufnr integer
 ---@param view CsvView.View
 function M.attach(bufnr, view)
+  bufnr = buf.resolve_bufnr(bufnr)
   if M._views[bufnr] then
     vim.notify("csvview: already attached for this buffer.")
     return
@@ -252,6 +254,7 @@ end
 --- detach view for buffer
 ---@param bufnr integer
 function M.detach(bufnr)
+  bufnr = buf.resolve_bufnr(bufnr)
   if not M._views[bufnr] then
     return
   end
@@ -263,6 +266,7 @@ end
 ---@param bufnr integer
 ---@return CsvView.View?
 function M.get(bufnr)
+  bufnr = buf.resolve_bufnr(bufnr)
   return M._views[bufnr]
 end
 


### PR DESCRIPTION
Allow using bufnr=0 as an argument for the following APIs to refer to the current buffer:

- `csvview.enable()`
- `csvview.disable()`
- `csvview.toggle()`