### PR TITLE
feat(jump): support repeating for jump motions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ lua require('csvview').setup()
     },
     jump_next_field_start = {
       function()
-        require("csvview.jump").next_field_start()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").next_field_start()
+        end
       end,
       desc = "[csvview] Jump to the next start of the field",
       noremap = true,
@@ -202,7 +204,9 @@ lua require('csvview').setup()
     },
     jump_prev_field_start = {
       function()
-        require("csvview.jump").prev_field_start()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").prev_field_start()
+        end
       end,
       desc = "[csvview] Jump to the previous start of the field",
       noremap = true,
@@ -210,7 +214,9 @@ lua require('csvview').setup()
     },
     jump_next_field_end = {
       function()
-        require("csvview.jump").next_field_end()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").next_field_end()
+        end
       end,
       desc = "[csvview] Jump to the next end of the field",
       noremap = true,
@@ -218,7 +224,9 @@ lua require('csvview').setup()
     },
     jump_prev_field_end = {
       function()
-        require("csvview.jump").prev_field_end()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").prev_field_end()
+        end
       end,
       desc = "[csvview] Jump to the previous end of the field",
       noremap = true,
@@ -226,7 +234,7 @@ lua require('csvview').setup()
     },
     jump_next_row = {
       function()
-        require("csvview.jump").field(0, { pos = { 1, 0 }, anchor = "end" })
+        require("csvview.jump").field(0, { pos = { vim.v.count1, 0 }, anchor = "end" })
       end,
       desc = "[csvview] Jump to the next row",
       noremap = true,
@@ -234,7 +242,7 @@ lua require('csvview').setup()
     },
     jump_prev_row = {
       function()
-        require("csvview.jump").field(0, { pos = { -1, 0 }, anchor = "end" })
+        require("csvview.jump").field(0, { pos = { -vim.v.count1, 0 }, anchor = "end" })
       end,
       desc = "[csvview] Jump to the previous row",
       noremap = true,

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -147,7 +147,9 @@ M.defaults = {
     },
     jump_next_field_start = {
       function()
-        require("csvview.jump").next_field_start()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").next_field_start()
+        end
       end,
       desc = "[csvview] Jump to the next start of the field",
       noremap = true,
@@ -155,7 +157,9 @@ M.defaults = {
     },
     jump_prev_field_start = {
       function()
-        require("csvview.jump").prev_field_start()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").prev_field_start()
+        end
       end,
       desc = "[csvview] Jump to the previous start of the field",
       noremap = true,
@@ -163,7 +167,9 @@ M.defaults = {
     },
     jump_next_field_end = {
       function()
-        require("csvview.jump").next_field_end()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").next_field_end()
+        end
       end,
       desc = "[csvview] Jump to the next end of the field",
       noremap = true,
@@ -171,7 +177,9 @@ M.defaults = {
     },
     jump_prev_field_end = {
       function()
-        require("csvview.jump").prev_field_end()
+        for _ = 1, vim.v.count1 do
+          require("csvview.jump").prev_field_end()
+        end
       end,
       desc = "[csvview] Jump to the previous end of the field",
       noremap = true,
@@ -179,7 +187,7 @@ M.defaults = {
     },
     jump_next_row = {
       function()
-        require("csvview.jump").field(0, { pos = { 1, 0 }, anchor = "end" })
+        require("csvview.jump").field(0, { pos = { vim.v.count1, 0 }, anchor = "end" })
       end,
       desc = "[csvview] Jump to the next row",
       noremap = true,
@@ -187,7 +195,7 @@ M.defaults = {
     },
     jump_prev_row = {
       function()
-        require("csvview.jump").field(0, { pos = { -1, 0 }, anchor = "end" })
+        require("csvview.jump").field(0, { pos = { -vim.v.count1, 0 }, anchor = "end" })
       end,
       desc = "[csvview] Jump to the previous row",
       noremap = true,


### PR DESCRIPTION
Add support for repeating jump motions using vim.v.count1. This enhancement allows users to repeat jump actions multiple times by specifying a count before the command. Updated README.md and config.lua to reflect these changes.