### PR TITLE
fix(#33): Temporarily disable tabular view during buffer preview with `inccommand=nosplit`

### DIFF
--- a/lua/csvview/buf.lua
+++ b/lua/csvview/buf.lua
@@ -51,6 +51,7 @@ function M.attach(bufnr, callbacks)
       on_changedtick = wrap_buf_attach_handler(callbacks.on_changedtick),
       on_reload = wrap_buf_attach_handler(callbacks.on_reload),
       on_detach = wrap_buf_attach_handler(callbacks.on_detach),
+      preview = true, -- for inccommand
     })
   end
 


### PR DESCRIPTION
Ideally, I would like to reflect the updates even during inccommand, but I will prioritize error handling.