### PR TITLE
feat(view): Support sticky header

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,10 +371,11 @@ vim.api.nvim_create_autocmd("User", {
 
 ## 🌈 Highlights
 
-| Group                | Default            | Description         |
-| -------------------- | ------------------ | ------------------- |
-| **CsvViewDelimiter** | link to `Comment`  | used for `,`        |
-| **CsvViewComment**   | link to `Comment`  | used for comment    |
+| Group                            | Default                    | Description                      |
+| -------------------------------- | -------------------------- | -------------------------------- |
+| **CsvViewDelimiter**             | link to `Comment`          | used for `,`                     |
+| **CsvViewComment**               | link to `Comment`          | used for comment                 |
+| **CsvViewStickyHeaderSeparator** | link to `CsvViewDelimiter` | used for sticky header separator |
 
 > [!NOTE]
 > For field highlighting, this plugin utilizes the `csvCol0` ~ `csvCol8` highlight groups that are used by Neovim's built-in CSV syntax highlighting.

--- a/README.md
+++ b/README.md
@@ -147,14 +147,17 @@ lua require('csvview').setup()
     --- The display method of the delimiter
     --- "highlight" highlights the delimiter
     --- "border" displays the delimiter with `│`
+    --- You can also specify it on the command line.
+    --- e.g:
+    --- :CsvViewEnable display_mode=border
     ---@type CsvView.Options.View.DisplayMode
     display_mode = "highlight",
 
     --- The line number of the header
     --- If this is set, the line is treated as a header. and used for sticky header feature.
     --- see also: `view.sticky_header`
-    --- @type integer?
-    header_lnum = nil,
+    --- @type integer|false
+    header_lnum = false,
 
     --- The sticky header feature settings
     --- If `view.header_lnum` is set, the header line is displayed at the top of the window.
@@ -164,7 +167,8 @@ lua require('csvview').setup()
       enabled = true,
 
       --- The separator character for the sticky header window
-      --- @type string?
+      --- set `false` to disable the separator
+      --- @type string|false
       separator = "─",
     },
   },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A comfortable CSV/TSV editing plugin for Neovim.
 
-![csvview](https://github.com/hat0uma/csvview.nvim/assets/55551571/27130f41-98f5-445d-a9eb-643b31e0b96b)
+<div align="center">
+  <video controls src="https://github.com/user-attachments/assets/f529b978-9ae4-4413-b73a-f0fa431c900d"></video>
+</div>
 
 ## ✨ Features
 
@@ -11,6 +13,7 @@ A comfortable CSV/TSV editing plugin for Neovim.
 - **Asynchronous Parsing**: Smoothly handles large CSV files without blocking.
 - **Text Objects & Motions**: Conveniently select fields or move across fields/rows.
 - **Comment Ignoring**: Skips specified comment lines from the table display.
+- **Sticky Header**: Keeps the header row visible while scrolling.
 - **Flexible Settings**: Customizable delimiter and comment prefix.
 - **Two Display Modes**:
   - `highlight`: Highlights delimiters.
@@ -91,6 +94,7 @@ lua require('csvview').setup()
 
     --- The delimiter character
     --- You can specify a string, a table of delimiter characters for each file type, or a function that returns a delimiter character.
+    --- Currently, only fixed-length strings are supported. Regular expressions such as \s+ are not supported.
     --- e.g:
     ---  delimiter = ","
     ---  delimiter = function(bufnr) return "," end
@@ -145,6 +149,24 @@ lua require('csvview').setup()
     --- "border" displays the delimiter with `│`
     ---@type CsvView.Options.View.DisplayMode
     display_mode = "highlight",
+
+    --- The line number of the header
+    --- If this is set, the line is treated as a header. and used for sticky header feature.
+    --- see also: `view.sticky_header`
+    --- @type integer?
+    header_lnum = nil,
+
+    --- The sticky header feature settings
+    --- If `view.header_lnum` is set, the header line is displayed at the top of the window.
+    sticky_header = {
+      --- Whether to enable the sticky header feature
+      --- @type boolean
+      enabled = true,
+
+      --- The separator character for the sticky header window
+      --- @type string?
+      separator = "─",
+    },
   },
 
   --- Keymaps for csvview.
@@ -176,78 +198,7 @@ lua require('csvview').setup()
   --- Actions for keymaps.
   ---@type CsvView.Options.Actions
   actions = {
-    textobject_field_inner = {
-      function()
-        require("csvview.textobject").field(0, { include_delimiter = false })
-      end,
-      desc = "[csvview] Select the current field",
-      noremap = true,
-      silent = true,
-    },
-    textobject_field_outer = {
-      function()
-        require("csvview.textobject").field(0, { include_delimiter = true })
-      end,
-      desc = "[csvview] Select the current field with delimiter",
-      noremap = true,
-      silent = true,
-    },
-    jump_next_field_start = {
-      function()
-        for _ = 1, vim.v.count1 do
-          require("csvview.jump").next_field_start()
-        end
-      end,
-      desc = "[csvview] Jump to the next start of the field",
-      noremap = true,
-      silent = true,
-    },
-    jump_prev_field_start = {
-      function()
-        for _ = 1, vim.v.count1 do
-          require("csvview.jump").prev_field_start()
-        end
-      end,
-      desc = "[csvview] Jump to the previous start of the field",
-      noremap = true,
-      silent = true,
-    },
-    jump_next_field_end = {
-      function()
-        for _ = 1, vim.v.count1 do
-          require("csvview.jump").next_field_end()
-        end
-      end,
-      desc = "[csvview] Jump to the next end of the field",
-      noremap = true,
-      silent = true,
-    },
-    jump_prev_field_end = {
-      function()
-        for _ = 1, vim.v.count1 do
-          require("csvview.jump").prev_field_end()
-        end
-      end,
-      desc = "[csvview] Jump to the previous end of the field",
-      noremap = true,
-      silent = true,
-    },
-    jump_next_row = {
-      function()
-        require("csvview.jump").field(0, { pos = { vim.v.count1, 0 }, anchor = "end" })
-      end,
-      desc = "[csvview] Jump to the next row",
-      noremap = true,
-      silent = true,
-    },
-    jump_prev_row = {
-      function()
-        require("csvview.jump").field(0, { pos = { -vim.v.count1, 0 }, anchor = "end" })
-      end,
-      desc = "[csvview] Jump to the previous row",
-      noremap = true,
-      silent = true,
-    },
+    -- See lua/csvview/config.lua
   },
 }
 ```
@@ -265,6 +216,23 @@ After opening a CSV file, use the following commands to interact with the plugin
 | `:CsvViewEnable [options]` | Enable CSV view with the specified options.      |
 | `:CsvViewDisable`          | Disable CSV view.                                |
 | `:CsvViewToggle [options]` | Toggle CSV view with the specified options.      |
+
+#### Command Options
+
+- **`delimiter`** (string):  
+  Specifies the field delimiter character. See `options.parser.delimiter`.
+
+- **`quote_char`** (string):  
+  The quote character for enclosing fields. See `options.parser.quote_char`.
+
+- **`comment`** (string):  
+  The comment prefix character. See `options.parser.comments`.
+
+- **`display_mode`** (string):  
+  Method for displaying delimiters. Possible values are `highlight` and `border`. See `options.view.display_mode`.
+
+- **`header_lnum`** (number):  
+  Line number (1-based) to treat as a header. If set, that line remains “sticky” at the top when scrolling. See `options.view.header_lnum`.
 
 ### Example
 
@@ -400,3 +368,7 @@ Contributions are welcome! Please open an issue or submit a pull request on GitH
 ## 📄 License
 
 Distributed under the MIT License.
+
+## 👏 Acknowledgements
+
+- [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) for inspiration of the sticky-header feature.

--- a/lua/csvview/buf.lua
+++ b/lua/csvview/buf.lua
@@ -16,6 +16,14 @@ end
 ---@param bufnr integer
 ---@return integer?
 function M.get_win(bufnr)
+  -- Prefer current window
+  local current_win = vim.api.nvim_get_current_win()
+  local current_buf = vim.api.nvim_win_get_buf(current_win)
+  if current_buf == bufnr then
+    return current_win
+  end
+
+  -- Find window
   for _, winid in ipairs(vim.api.nvim_list_wins()) do
     if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
       return winid

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -50,6 +50,7 @@ M.defaults = {
 
     --- The delimiter character
     --- You can specify a string, a table of delimiter characters for each file type, or a function that returns a delimiter character.
+    --- Currently, only fixed-length strings are supported. Regular expressions such as \s+ are not supported.
     --- e.g:
     ---  delimiter = ","
     ---  delimiter = function(bufnr) return "," end

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -11,13 +11,13 @@ local M = {}
 ---@field min_column_width? integer
 ---@field spacing? integer
 ---@field display_mode? CsvView.Options.View.DisplayMode
----@field header_lnum? integer
+---@field header_lnum? integer|false
 ---@field sticky_header? CsvView.Options.View.StickyHeader
 ---@alias CsvView.Options.View.DisplayMode "highlight" | "border"
 
 ---@class CsvView.Options.View.StickyHeader
 ---@field enabled? boolean
----@field separator? string
+---@field separator? string|false
 
 ---@class CsvView.Options.Keymaps
 ---@field textobject_field_inner? CsvView.Keymap
@@ -112,8 +112,8 @@ M.defaults = {
     --- The line number of the header
     --- If this is set, the line is treated as a header. and used for sticky header feature.
     --- see also: `view.sticky_header`
-    --- @type integer?
-    header_lnum = nil,
+    --- @type integer|false
+    header_lnum = false,
 
     --- The sticky header feature settings
     --- If `view.header_lnum` is set, the header line is displayed at the top of the window.
@@ -123,7 +123,8 @@ M.defaults = {
       enabled = true,
 
       --- The separator character for the sticky header window
-      --- @type string?
+      --- set `false` to disable the separator
+      --- @type string|false
       separator = "─",
     },
   },

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -11,7 +11,13 @@ local M = {}
 ---@field min_column_width? integer
 ---@field spacing? integer
 ---@field display_mode? CsvView.Options.View.DisplayMode
+---@field header_lnum? integer
+---@field sticky_header? CsvView.Options.View.StickyHeader
 ---@alias CsvView.Options.View.DisplayMode "highlight" | "border"
+
+---@class CsvView.Options.View.StickyHeader
+---@field enabled? boolean
+---@field separator? string
 
 ---@class CsvView.Options.Keymaps
 ---@field textobject_field_inner? CsvView.Keymap
@@ -101,6 +107,24 @@ M.defaults = {
     --- :CsvViewEnable display_mode=border
     ---@type CsvView.Options.View.DisplayMode
     display_mode = "highlight",
+
+    --- The line number of the header
+    --- If this is set, the line is treated as a header. and used for sticky header feature.
+    --- see also: `view.sticky_header`
+    --- @type integer?
+    header_lnum = nil,
+
+    --- The sticky header feature settings
+    --- If `view.header_lnum` is set, the header line is displayed at the top of the window.
+    sticky_header = {
+      --- Whether to enable the sticky header feature
+      --- @type boolean
+      enabled = true,
+
+      --- The separator character for the sticky header window
+      --- @type string?
+      separator = "─",
+    },
   },
 
   --- Keymaps for csvview.

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -5,6 +5,7 @@ local get_view = require("csvview.view").get
 local attach_view = require("csvview.view").attach
 local detach_view = require("csvview.view").detach
 local setup_view = require("csvview.view").setup
+local sticky_header = require("csvview.sticky_header")
 
 local CsvViewMetrics = require("csvview.metrics")
 local buf = require("csvview.buf")
@@ -138,6 +139,7 @@ end
 function M.setup(opts)
   config.setup(opts)
   setup_view()
+  sticky_header.setup()
 end
 
 return M

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -1,0 +1,287 @@
+local M = {}
+
+M._sticky_header_wins = {} --- @type table<integer,integer> winid -> sticky-header winid
+
+--- Sync the horizontal scroll of the sticky header window with the main window.
+---@param winid integer csvview attached window
+---@param header_winid integer sticky-header window
+---@param header_lnum integer header line number
+local function sync_horizontal_scroll(winid, header_winid, header_lnum)
+  local win_view = vim.api.nvim_win_call(winid, vim.fn.winsaveview) ---@type vim.fn.winsaveview.ret
+  vim.api.nvim_win_call(header_winid, function()
+    local current = vim.fn.winsaveview()
+    if current.leftcol ~= win_view.leftcol or current.lnum ~= header_lnum then
+      vim.fn.winrestview({ lnum = header_lnum, leftcol = win_view.leftcol })
+    end
+  end)
+end
+
+--- Get the 'statuscolumn' option of the window, or the default value if it is empty.
+---@param winid integer window ID
+---@return string
+local function get_statuscolumn_or_default(winid)
+  local statuscolumn = vim.api.nvim_get_option_value("statuscolumn", { win = winid, scope = "local" }) ---@type string
+  if statuscolumn ~= "" then
+    return statuscolumn
+  end
+
+  -- default
+  return "%C%=%s%=%l "
+end
+
+--- Convert the dictionary returned by nvim_eval_statusline() into a
+--- 'statuscolumn'-compatible string that reproduces the highlights.
+--- @param eval_result { str: string, width: number, highlights: {start: number, group:string, groups: string[] }[] } A dictionary from nvim_eval_statusline()
+--- @return string converted A string in 'statuscolumn' format.
+local function format_to_stc_string(eval_result)
+  local text = eval_result.str or ""
+  local highlights = eval_result.highlights
+  if not highlights or #highlights == 0 then
+    return text
+  end
+
+  local pieces = {}
+  for i, hl in ipairs(highlights) do
+    local start_index = hl.start
+    local end_index = (i < #highlights) and highlights[i + 1].start or #text
+    -- Extract the string corresponding to the current segment
+    local segment = string.sub(text, start_index + 1, end_index)
+
+    -- Use the last highlight group
+    local groups = hl.groups or {}
+    local group_name = #groups > 0 and groups[#groups] or "Normal"
+
+    -- %#…# to start highlight, %* to end highlight
+    table.insert(pieces, "%#" .. group_name .. "#" .. segment .. "%*")
+  end
+
+  return table.concat(pieces)
+end
+
+--- Copy window options from one window to another
+--- @param names string[]: List of option names to copy
+--- @param source integer: Source window ID
+--- @param target integer: Target window ID
+local function copy_win_options(names, source, target)
+  for _, name in ipairs(names) do
+    local value = vim.api.nvim_get_option_value(name, { win = source, scope = "local" })
+    vim.api.nvim_set_option_value(name, value, { win = target, scope = "local" })
+  end
+end
+
+--- Set window options for the sticky header window
+---@param sticky_header_winid integer
+---@param winid integer
+local function set_sticky_header_win_options(sticky_header_winid, winid)
+  -- Set special statuscolumn for sticky header window
+  local statuscolumn = string.format("%%{%%v:lua.require('csvview.sticky_header').statuscolumn(%d)%%}", winid)
+  vim.api.nvim_set_option_value("statuscolumn", statuscolumn, {
+    win = sticky_header_winid,
+    scope = "local",
+  })
+
+  -- Copy window options from the main window to the sticky header window
+  copy_win_options({
+    "relativenumber",
+    "signcolumn",
+    "foldcolumn",
+    "numberwidth",
+  }, winid, sticky_header_winid)
+end
+
+--- Get the border characters for the sticky header window.
+---@param opts CsvView.InternalOptions
+---@return (string| { [1]:string, [2]:string })[]?
+local function get_sticky_header_border(opts)
+  if not opts.view.sticky_header.separator then
+    return nil
+  end
+
+  local separator = { opts.view.sticky_header.separator, "CsvViewDelimiter" }
+  return { "", "", "", "", separator, separator, separator, "" }
+end
+
+--- Display sticky header.
+---@param winid integer
+---@param view CsvView.View
+local function show_sticky_header(winid, view)
+  -- Open sticky header window
+  -- This is achieved by opening the original buffer in a 1-line size floating window.
+  -- Initially, I tried to display it by overlaying virt_text on the first line, but I decided to use a floating window due to the following issues:
+  --  - When smoothscroll is enabled, the header line, which should be fixed, appears to scroll.
+  --  - Cannot overlay statuscolumn (line number, etc.).
+  local win_width = vim.api.nvim_win_get_width(winid)
+  local win_opts = { ---@type vim.api.keyset.win_config
+    win = winid,
+    relative = "win",
+    width = win_width,
+    height = 1,
+    row = 0,
+    col = 0,
+    focusable = false,
+    style = "minimal",
+    border = get_sticky_header_border(view.opts),
+  }
+
+  -- Create window for sticky header, if not exists.
+  local sticky_header_winid = M._sticky_header_wins[winid]
+  if not sticky_header_winid or not vim.api.nvim_win_is_valid(sticky_header_winid) then
+    win_opts.noautocmd = true
+    sticky_header_winid = vim.api.nvim_open_win(view.bufnr, false, win_opts)
+    M._sticky_header_wins[winid] = sticky_header_winid
+  else
+    vim.api.nvim_win_set_config(sticky_header_winid, win_opts)
+    if vim.api.nvim_win_get_buf(sticky_header_winid) ~= view.bufnr then
+      vim.api.nvim_win_set_buf(sticky_header_winid, view.bufnr)
+    end
+  end
+
+  -- Mark as sticky header window
+  vim.w[sticky_header_winid].csvview_sticky_header_win = true
+
+  -- Set window options
+  set_sticky_header_win_options(sticky_header_winid, winid)
+end
+
+--- Close header window
+---@param winid integer
+local function close_sticky_header_win_if_opened(winid)
+  local header_win = M._sticky_header_wins[winid]
+  if not header_win then
+    return
+  end
+
+  -- Close
+  if vim.api.nvim_win_is_valid(header_win) then
+    vim.api.nvim_win_close(header_win, true)
+  end
+  M._sticky_header_wins[winid] = nil
+end
+
+--- Determine if the sticky header should be shown.
+---@param winid integer
+---@param view CsvView.View
+---@return boolean
+local function should_show_sticky_header(winid, view)
+  -- Do not show if the sticky_header option is disabled
+  if not view.opts.view.sticky_header.enabled then
+    return false
+  end
+
+  -- Do not show if the header line is not set
+  local header_lnum = view.opts.view.header_lnum
+  if not header_lnum then
+    return false
+  end
+
+  -- Do not show if the header line is visible in the window
+  local top_lnum = vim.fn.line("w0", winid)
+  if top_lnum <= header_lnum then
+    return false
+  end
+
+  -- Hide if the cursor overlaps with the sticky header drawing position
+  -- Also hide if it overlaps with the separator.
+  local cur_lnum = vim.fn.line(".", winid)
+  local header_bot_lnum = top_lnum + (view.opts.view.sticky_header.separator and 1 or 0)
+  if cur_lnum <= header_bot_lnum then
+    return false
+  end
+
+  return true
+end
+
+--- Get the CsvView.View that is displayed in the window.
+---@param winid integer window ID
+---@return CsvView.View? view
+local function get_opened_csvview(winid)
+  if not vim.api.nvim_win_is_valid(winid) then
+    return
+  end
+
+  -- sticky header window
+  if vim.w[winid].csvview_sticky_header_win then
+    return
+  end
+
+  local bufnr = vim.api.nvim_win_get_buf(winid)
+  local view = require("csvview.view").get(bufnr)
+  return view
+end
+
+--- statuscolumn function for sticky header window.
+---@param winid integer csvview attached window
+---@return string statuscolumn
+function M.statuscolumn(winid)
+  -- Evaluate the status column in the original window and reflect the result in the sticky header window.
+  -- This allows correct display of things like relativenumber.
+  local statuscolumn = get_statuscolumn_or_default(winid)
+  local data = vim.api.nvim_eval_statusline(statuscolumn, {
+    use_statuscol_lnum = vim.v.lnum,
+    winid = winid,
+    highlights = true,
+    fillchar = " ",
+  })
+
+  ---@diagnostic disable-next-line: param-type-mismatch
+  return format_to_stc_string(data)
+end
+
+--- Redraw all sticky headers
+function M.redraw()
+  local wins = vim.api.nvim_tabpage_list_wins(0)
+  for _, winid in ipairs(wins) do
+    local view = get_opened_csvview(winid)
+    if view and should_show_sticky_header(winid, view) then
+      show_sticky_header(winid, view)
+      sync_horizontal_scroll(winid, M._sticky_header_wins[winid], view.opts.view.header_lnum)
+    else
+      close_sticky_header_win_if_opened(winid)
+    end
+  end
+end
+
+--- Setup the sticky header feature.
+function M.setup()
+  local group = vim.api.nvim_create_augroup("csvview.sticky_header", {})
+  vim.api.nvim_create_autocmd({
+    "WinScrolled",
+    "CursorMoved",
+    "BufEnter",
+    "WinEnter",
+    "VimResized",
+    "WinResized",
+  }, {
+    callback = M.redraw,
+    group = group,
+  })
+  vim.api.nvim_create_autocmd("OptionSet", {
+    pattern = {
+      "number",
+      "relativenumber",
+      "numberwidth",
+      "signcolumn",
+      "foldcolumn",
+    },
+    callback = M.redraw,
+    group = group,
+  })
+  vim.api.nvim_create_autocmd("User", {
+    pattern = {
+      "CsvViewAttach",
+      "CsvViewDetach",
+    },
+    callback = vim.schedule_wrap(M.redraw),
+    group = group,
+  })
+
+  vim.api.nvim_create_autocmd({ "WinClosed" }, {
+    callback = function(args)
+      local winid = assert(tonumber(args.match))
+      close_sticky_header_win_if_opened(winid)
+    end,
+    group = group,
+  })
+end
+
+return M

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -26,6 +26,13 @@ local function get_statuscolumn_or_default(winid)
   end
 
   -- default
+  if vim.fn.has("nvim-0.11") ~= 1 then
+    -- below neovim 0.11
+    -- https://github.com/neovim/neovim/pull/29357
+    local relnum = vim.api.nvim_get_option_value("relativenumber", { win = winid, scope = "local" }) ---@type boolean
+    return relnum and "%C%=%s%=%r " or "%C%=%s%=%l "
+  end
+
   return "%C%=%s%=%l "
 end
 
@@ -48,7 +55,7 @@ local function format_to_stc_string(eval_result)
     local segment = string.sub(text, start_index + 1, end_index)
 
     -- Use the last highlight group
-    local groups = hl.groups or {}
+    local groups = hl.groups or { hl.group } -- fallback to hl.group for compatibility
     local group_name = #groups > 0 and groups[#groups] or "Normal"
 
     -- %#…# to start highlight, %* to end highlight

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -80,12 +80,17 @@ end
 ---@param sticky_header_winid integer
 ---@param winid integer
 local function set_sticky_header_win_options(sticky_header_winid, winid)
-  -- Set special statuscolumn for sticky header window
-  local statuscolumn = string.format("%%{%%v:lua.require('csvview.sticky_header').statuscolumn(%d)%%}", winid)
-  vim.api.nvim_set_option_value("statuscolumn", statuscolumn, {
+  local opts = { ---@type vim.api.keyset.option
     win = sticky_header_winid,
     scope = "local",
-  })
+  }
+
+  -- Set special statuscolumn for sticky header window
+  local statuscolumn = string.format("%%{%%v:lua.require('csvview.sticky_header').statuscolumn(%d)%%}", winid)
+  vim.api.nvim_set_option_value("statuscolumn", statuscolumn, opts)
+
+  -- use Normal instead of NormalFloat
+  vim.api.nvim_set_option_value("winhl", "Normal:Normal", opts)
 
   -- Copy window options from the main window to the sticky header window
   copy_win_options({

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -97,7 +97,7 @@ local function get_sticky_header_border(opts)
     return nil
   end
 
-  local separator = { opts.view.sticky_header.separator, "CsvViewDelimiter" }
+  local separator = { opts.view.sticky_header.separator, "CsvViewStickyHeaderSeparator" }
   return { "", "", "", "", separator, separator, separator, "" }
 end
 
@@ -243,6 +243,10 @@ end
 
 --- Setup the sticky header feature.
 function M.setup()
+  -- Highlights
+  vim.api.nvim_set_hl(0, "CsvViewStickyHeaderSeparator", { link = "CsvViewDelimiter", default = true })
+
+  -- Autocommands
   local group = vim.api.nvim_create_augroup("csvview.sticky_header", {})
   vim.api.nvim_create_autocmd({
     "WinScrolled",

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -40,7 +40,11 @@ local cmdline = Cmdline:new({
     ---@param options CsvView.Options
     ---@param value string
     set = function(options, value)
-      options.view.header_lnum = tonumber(value)
+      if value == "false" then
+        options.view.header_lnum = false
+      else
+        options.view.header_lnum = tonumber(value)
+      end
     end,
   },
 })

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -35,6 +35,14 @@ local cmdline = Cmdline:new({
     end,
     candidates = { "highlight", "border" },
   },
+  {
+    name = "header_lnum",
+    ---@param options CsvView.Options
+    ---@param value string
+    set = function(options, value)
+      options.view.header_lnum = tonumber(value)
+    end,
+  },
 })
 
 local function create_empty_opts()

--- a/tests/sticky_header_spec.lua
+++ b/tests/sticky_header_spec.lua
@@ -106,6 +106,7 @@ describe("sticky_header", function()
         local e = vim.api.nvim_eval_statusline(statuscolumn, {
           winid = winid,
           use_statuscol_lnum = case.opts.view.header_lnum,
+          fillchar = " ",
         })
 
         local expected = string.format("abc%" .. vim.wo[winid].numberwidth - 1 .. "ddef", case.opts.view.header_lnum)
@@ -133,6 +134,7 @@ describe("sticky_header", function()
         local e = vim.api.nvim_eval_statusline(statuscolumn, {
           winid = winid,
           use_statuscol_lnum = case.opts.view.header_lnum,
+          fillchar = " ",
         })
 
         -- relativenumber is calculated based on the current cursor position

--- a/tests/sticky_header_spec.lua
+++ b/tests/sticky_header_spec.lua
@@ -1,0 +1,182 @@
+---@diagnostic disable: await-in-sync
+local config = require("csvview.config")
+local csvview = require("csvview")
+
+---@class CsvView.Tests.StickyHeaderCase
+---@field name string
+---@field winview vim.fn.winrestview.dict
+---@field winopts? { [1]: string, [2]: any }[]
+---@field opts CsvView.Options
+---@field assert fun(case: CsvView.Tests.StickyHeaderCase)
+
+local function get_sticky_header_win()
+  local wins = vim.api.nvim_tabpage_list_wins(0)
+  for _, winid in ipairs(wins) do
+    if vim.w[winid].csvview_sticky_header_win then
+      return winid
+    end
+  end
+
+  return nil
+end
+
+local function should_show_sticky_header()
+  assert.are.not_nil(get_sticky_header_win(), "Sticky header window should be opened")
+end
+
+local function should_not_show_sticky_header()
+  assert.are_nil(get_sticky_header_win(), "Sticky header window should not be opened")
+end
+
+describe("sticky_header", function()
+  before_each(function()
+    config.setup()
+    csvview.setup()
+  end)
+
+  ---@type CsvView.Tests.StickyHeaderCase[]
+  local cases = {
+    {
+      name = "does not show when the sticky_header option is disabled",
+      winview = { lnum = 100, col = 0 },
+      opts = { view = { sticky_header = { enabled = false, separator = "-" }, header_lnum = 1 } },
+      assert = should_not_show_sticky_header,
+    },
+    {
+      name = "does not show when the header line is not set",
+      winview = { lnum = 100, col = 0 },
+      opts = { view = { sticky_header = { enabled = true, separator = "-" } } },
+      assert = should_not_show_sticky_header,
+    },
+    {
+      name = "does not show when the header is in the window",
+      winview = { topline = 1, lnum = 5, col = 0 },
+      opts = { view = { sticky_header = { enabled = true, separator = "-" }, header_lnum = 1 } },
+      assert = should_not_show_sticky_header,
+    },
+    {
+      name = "hides when the cursor overlaps with the header drawing position",
+      winview = { topline = 10, lnum = 10, col = 0 },
+      opts = { view = { sticky_header = { enabled = true, separator = "-" }, header_lnum = 1 } },
+      assert = should_not_show_sticky_header,
+    },
+    {
+      name = "hides when the cursor overlaps with the separator",
+      winview = { topline = 10, lnum = 11, col = 0 },
+      opts = { view = { sticky_header = { enabled = true, separator = "-" }, header_lnum = 5 } },
+      assert = should_not_show_sticky_header,
+    },
+    {
+      name = "shows when the header is out of the window",
+      winview = { topline = 10, lnum = 11, col = 0 },
+      opts = { view = { sticky_header = { enabled = true, separator = false }, header_lnum = 5 } },
+      assert = should_show_sticky_header,
+    },
+    {
+      name = "syncs with the current window horizontal scroll",
+      winview = { topline = 10, lnum = 15, leftcol = 2, col = 2 },
+      winopts = { { "sidescrolloff", 0 }, { "scrolloff", 0 } },
+      opts = { view = { sticky_header = { enabled = true, separator = false }, header_lnum = 5 } },
+      assert = function(case)
+        local winid = get_sticky_header_win()
+        assert.are.not_nil(winid)
+        assert(winid) -- suppress luals check
+
+        local winview = vim.api.nvim_win_call(winid, vim.fn.winsaveview) ---@type vim.fn.winsaveview.ret
+        assert.are.equal(case.winview.leftcol, winview.leftcol)
+        assert.are.equal(case.opts.view.header_lnum, winview.lnum)
+      end,
+    },
+    {
+      name = "computes the correct gutter column when statuscolumn is set",
+      winview = { topline = 10, lnum = 15, col = 2 },
+      winopts = {
+        { "number", true },
+        { "numberwidth", 4 },
+        { "relativenumber", false },
+        { "statuscolumn", "abc%ldef" },
+      },
+      opts = { view = { sticky_header = { enabled = true, separator = false }, header_lnum = 5 } },
+      assert = function(case)
+        local winid = get_sticky_header_win()
+        assert.are.not_nil(winid)
+
+        -- Evaluate the statusline
+        local statuscolumn = vim.wo[winid].statuscolumn
+        local e = vim.api.nvim_eval_statusline(statuscolumn, {
+          winid = winid,
+          use_statuscol_lnum = case.opts.view.header_lnum,
+        })
+
+        local expected = string.format("abc%" .. vim.wo[winid].numberwidth - 1 .. "ddef", case.opts.view.header_lnum)
+        assert.are.equal(expected, e.str)
+      end,
+    },
+    {
+      name = "computes the correct gutter column when no statuscolumn is set",
+      winview = { topline = 10, lnum = 15, col = 2 },
+      winopts = {
+        { "number", true },
+        { "relativenumber", true },
+        { "numberwidth", 4 },
+        { "signcolumn", "no" },
+        { "foldcolumn", "0" },
+        { "statuscolumn", nil },
+      },
+      opts = { view = { sticky_header = { enabled = true, separator = false }, header_lnum = 1 } },
+      assert = function(case)
+        local winid = get_sticky_header_win()
+        assert.are.not_nil(winid)
+
+        -- Evaluate the statusline
+        local statuscolumn = vim.wo[winid].statuscolumn
+        local e = vim.api.nvim_eval_statusline(statuscolumn, {
+          winid = winid,
+          use_statuscol_lnum = case.opts.view.header_lnum,
+        })
+
+        -- relativenumber is calculated based on the current cursor position
+        local relnum = case.winview.lnum - case.opts.view.header_lnum
+        local expected = string.format("%" .. (vim.wo[winid].numberwidth - 1) .. "d ", relnum)
+        assert.are.equal(expected, e.str)
+      end,
+    },
+  }
+
+  vim.cmd.edit("tests/fixtures/test.csv")
+  for _, case in ipairs(cases) do
+    if csvview.is_enabled(0) then
+      csvview.disable(0)
+    end
+
+    -- Set the window options
+    local winid = vim.api.nvim_get_current_win()
+    for _, opt in ipairs(case.winopts or {}) do
+      local name = opt[1]
+      local value = opt[2]
+      vim.api.nvim_set_option_value(name, value, { win = winid, scope = "local" })
+    end
+
+    it(case.name, function()
+      vim.fn.winrestview(case.winview)
+      vim.wait(1)
+
+      -- Enable csvview
+      local bufnr = vim.api.nvim_get_current_buf()
+      csvview.enable(bufnr, case.opts)
+      vim.wait(1)
+
+      -- Evaluate the expected result
+      case.assert(case)
+
+      -- Cleanup
+      csvview.disable(bufnr)
+    end)
+
+    -- Clear window options
+    for _, opt in ipairs(case.winopts or {}) do
+      local name = opt[1]
+      vim.api.nvim_set_option_value(name, nil, { win = winid, scope = "local" })
+    end
+  end
+end)

--- a/tests/sticky_header_spec.lua
+++ b/tests/sticky_header_spec.lua
@@ -91,10 +91,7 @@ describe("sticky_header", function()
       name = "computes the correct gutter column when statuscolumn is set",
       winview = { topline = 10, lnum = 15, col = 2 },
       winopts = {
-        { "number", true },
-        { "numberwidth", 4 },
-        { "relativenumber", false },
-        { "statuscolumn", "abc%ldef" },
+        { "statuscolumn", "abc%{v:lnum}def" },
       },
       opts = { view = { sticky_header = { enabled = true, separator = false }, header_lnum = 5 } },
       assert = function(case)
@@ -109,7 +106,7 @@ describe("sticky_header", function()
           fillchar = " ",
         })
 
-        local expected = string.format("abc%" .. vim.wo[winid].numberwidth - 1 .. "ddef", case.opts.view.header_lnum)
+        local expected = string.format("abc%ddef", case.opts.view.header_lnum)
         assert.are.equal(expected, e.str)
       end,
     },


### PR DESCRIPTION
## Description

This PR adds support for a sticky header feature. With this update, the header remains fixed during scrolling, making it easier for users to keep track of important information.

https://github.com/user-attachments/assets/c69b85f9-518f-47f6-9a2f-a709caa3a7cc

## TODO

- [x] Sync horizontal scrolling
- [x] Update status column (e.g., `relativenumber` and others)
- [x] Support multi-window 
- [x] Add tests
- [x] Update documentation


## Related Issues
#30 #31