### PR TITLE
feat(view):add custom highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,9 +349,8 @@ vim.api.nvim_create_autocmd("User", {
 | **CsvViewDelimiter**             | link to `Comment`          | used for `,`                     |
 | **CsvViewComment**               | link to `Comment`          | used for comment                 |
 | **CsvViewStickyHeaderSeparator** | link to `CsvViewDelimiter` | used for sticky header separator |
-
-> [!NOTE]
-> For field highlighting, this plugin utilizes the `csvCol0` ~ `csvCol8` highlight groups that are used by Neovim's built-in CSV syntax highlighting.
+| **CsvViewHeader**                | -                          | used for header highlighting     |
+| **CsvViewCol0** ~ **CsvViewCol8**| link to `csvCol0` ~ `csvCol8` | used for field highlighting      |
 
 ## 📝 TODO
 

--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ vim.api.nvim_create_autocmd("User", {
 | **CsvViewDelimiter**             | link to `Comment`          | used for `,`                     |
 | **CsvViewComment**               | link to `Comment`          | used for comment                 |
 | **CsvViewStickyHeaderSeparator** | link to `CsvViewDelimiter` | used for sticky header separator |
-| **CsvViewHeader**                | -                          | used for header highlighting     |
-| **CsvViewCol0** ~ **CsvViewCol8**| link to `csvCol0` ~ `csvCol8` | used for field highlighting      |
+| **CsvViewHeaderLine**            | -                          | used for header highlighting     |
+| **CsvViewCol0** ~ **CsvViewCol8**| link to `csvCol0` ~ `csvCol8` | used for field highlighting   |
 
 ## 📝 TODO
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ vim.api.nvim_create_autocmd("User", {
 | **CsvViewComment**               | link to `Comment`          | used for comment                 |
 | **CsvViewStickyHeaderSeparator** | link to `CsvViewDelimiter` | used for sticky header separator |
 | **CsvViewHeaderLine**            | -                          | used for header highlighting     |
-| **CsvViewCol0** ~ **CsvViewCol8**| link to `csvCol0` ~ `csvCol8` | used for field highlighting   |
+| **CsvViewCol0** to **CsvViewCol8**| link to `csvCol0` to `csvCol8` | used for field highlighting   |
 
 ## 📝 TODO
 

--- a/lua/csvview/buf.lua
+++ b/lua/csvview/buf.lua
@@ -12,6 +12,21 @@ function M.resolve_bufnr(bufnr)
   end
 end
 
+--- Get buffer attached window in tabpage
+---@param tabpage integer
+---@param bufnr integer
+---@return integer[]
+function M.tabpage_win_find(tabpage, bufnr)
+  return vim.tbl_filter(
+    --- @param winid integer
+    --- @return boolean
+    function(winid)
+      return vim.api.nvim_win_get_buf(winid) == bufnr
+    end,
+    vim.api.nvim_tabpage_list_wins(tabpage)
+  )
+end
+
 --- Get buffer attached window
 ---@param bufnr integer
 ---@return integer?

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -246,6 +246,17 @@ end
 --- setup
 ---@param opts? CsvView.Options
 function M.setup(opts)
+  local highlight_links = {
+    CsvViewDelimiter = "Comment",
+    CsvViewComment = "Comment",
+    CsvViewStickyHeaderSeparator = "CsvViewDelimiter",
+  }
+
+  -- set highlight links
+  for group, link in pairs(highlight_links) do
+    vim.api.nvim_set_hl(0, group, { link = link, default = true })
+  end
+
   M.options = vim.tbl_deep_extend("force", M.defaults, opts or {})
 end
 

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -269,6 +269,26 @@ function M.setup(opts)
     vim.api.nvim_set_hl(0, hl.name, { link = hl.link, default = true })
   end
 
+  if vim.fn.has("nvim-0.11") ~= 1 then
+    -- fallback for nvim < 0.11
+    -- see https://github.com/neovim/neovim/blob/master/runtime/syntax/csv.vim
+    local fallback_highlights = {
+      csvCol1 = "Statement",
+      csvCol2 = "Constant",
+      csvCol3 = "Type",
+      csvCol4 = "PreProc",
+      csvCol5 = "Identifier",
+      csvCol6 = "Special",
+      csvCol7 = "String",
+      csvCol8 = "Comment",
+    }
+    for name, link in pairs(fallback_highlights) do
+      if vim.tbl_isempty(vim.api.nvim_get_hl(0, { name = name })) then
+        vim.api.nvim_set_hl(0, name, { link = link, default = true })
+      end
+    end
+  end
+
   M.options = vim.tbl_deep_extend("force", M.defaults, opts or {})
 end
 

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -240,11 +240,9 @@ M.options = {}
 M._highlights = {
   { name = "CsvViewDelimiter", link = "Delimiter" },
   { name = "CsvViewComment", link = "Comment" },
+  { name = "CsvViewHeaderLine", link = nil },
   { name = "CsvViewStickyHeaderSeparator", link = "Delimiter" },
-  { name = "CsvViewHeader", link = nil },
   -- use built-in csv syntax highlight group.
-  -- csvCol0 ~ csvCol8
-  -- see https://github.com/neovim/neovim/blob/master/runtime/syntax/csv.vim
   { name = "CsvViewCol0", link = "csvCol0" },
   { name = "CsvViewCol1", link = "csvCol1" },
   { name = "CsvViewCol2", link = "csvCol2" },

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -236,6 +236,26 @@ M.defaults = {
 ---@diagnostic disable-next-line: missing-fields
 M.options = {}
 
+---@type { name: string, link?: string }[]
+M._highlights = {
+  { name = "CsvViewDelimiter", link = "Delimiter" },
+  { name = "CsvViewComment", link = "Comment" },
+  { name = "CsvViewStickyHeaderSeparator", link = "Delimiter" },
+  { name = "CsvViewHeader", link = nil },
+  -- use built-in csv syntax highlight group.
+  -- csvCol0 ~ csvCol8
+  -- see https://github.com/neovim/neovim/blob/master/runtime/syntax/csv.vim
+  { name = "CsvViewCol0", link = "csvCol0" },
+  { name = "CsvViewCol1", link = "csvCol1" },
+  { name = "CsvViewCol2", link = "csvCol2" },
+  { name = "CsvViewCol3", link = "csvCol3" },
+  { name = "CsvViewCol4", link = "csvCol4" },
+  { name = "CsvViewCol5", link = "csvCol5" },
+  { name = "CsvViewCol6", link = "csvCol6" },
+  { name = "CsvViewCol7", link = "csvCol7" },
+  { name = "CsvViewCol8", link = "csvCol8" },
+}
+
 --- get config
 ---@param opts? CsvView.Options
 ---@return CsvView.InternalOptions
@@ -246,15 +266,9 @@ end
 --- setup
 ---@param opts? CsvView.Options
 function M.setup(opts)
-  local highlight_links = {
-    CsvViewDelimiter = "Comment",
-    CsvViewComment = "Comment",
-    CsvViewStickyHeaderSeparator = "CsvViewDelimiter",
-  }
-
-  -- set highlight links
-  for group, link in pairs(highlight_links) do
-    vim.api.nvim_set_hl(0, group, { link = link, default = true })
+  -- Set colors
+  for _, hl in ipairs(M._highlights) do
+    vim.api.nvim_set_hl(0, hl.name, { link = hl.link, default = true })
   end
 
   M.options = vim.tbl_deep_extend("force", M.defaults, opts or {})

--- a/lua/csvview/errors.lua
+++ b/lua/csvview/errors.lua
@@ -39,32 +39,28 @@ local function tbl_remove_key(tbl, key)
   return value
 end
 
+--- Format error message
+---@param err string|CsvView.Error|nil
+---@return string
+function M.format_error(err)
+  if type(err) == "table" then
+    local stacktrace = tbl_remove_key(err, "stacktrace") or "No stacktrace available"
+    local err_msg = tbl_remove_key(err, "err") or "An unspecified error occurred"
+    return string.format("Error: %s\nDetails: %s\n%s", err_msg, vim.inspect(err), stacktrace)
+  elseif type(err) == "string" then
+    return err
+  else
+    return "An unknown error occurred."
+  end
+end
+
 --- Print error message
 --- @type fun(header: string, err: string|CsvView.Error|nil)
 M.print_structured_error = vim.schedule_wrap(function(header, err)
-  --- @type string
-  local msg
-
-  if type(err) == "table" then
-    -- extract error message and stacktrace
-    local stacktrace = tbl_remove_key(err, "stacktrace") or "No stacktrace available"
-    local err_msg = tbl_remove_key(err, "err") or "An unspecified error occurred"
-
-    -- format error message
-    msg = string.format(
-      "Error: %s\nDetails: %s\n%s",
-      err_msg,
-      -- vim.inspect(err, { newline = " ", indent = "" }),
-      vim.inspect(err),
-      stacktrace --
-    )
-  elseif type(err) == "string" then
-    msg = err
-  else
-    msg = "An unknown error occurred."
-  end
-
-  vim.notify(string.format("%s\n\n%s", header, msg), vim.log.levels.ERROR, { title = "csvview.nvim" })
+  local msg = M.format_error(err)
+  vim.notify(string.format("%s\n\n%s", header, msg), vim.log.levels.ERROR, {
+    title = "csvview.nvim",
+  })
 end)
 
 return M

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -93,17 +93,24 @@ function M.enable(bufnr, opts)
     buffer = bufnr,
   })
 
+  local orig_syntax = vim.bo[bufnr].syntax
+
   -- Register detach callback
   on_detach = function()
     vim.api.nvim_clear_autocmds({ group = group, buffer = bufnr })
     detach_bufevent_handle()
     metrics:clear()
     keymap.unregister(opts)
+    vim.bo[bufnr].syntax = orig_syntax
     vim.api.nvim_exec_autocmds("User", { pattern = "CsvViewDetach", data = bufnr })
   end
 
   -- Calculate metrics and attach view.
   metrics:compute_buffer(function()
+    -- disable builtin syntax highlighting.
+    -- NOTE: This is necessary to prevent syntax highlighting from interfering with the custom highlighting of the view.
+    vim.bo[bufnr].syntax = ""
+
     attach_view(bufnr, view)
     keymap.register(opts)
     vim.api.nvim_exec_autocmds("User", { pattern = "CsvViewAttach", data = bufnr })

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -90,7 +90,7 @@ local function set_sticky_header_win_options(sticky_header_winid, winid)
   vim.api.nvim_set_option_value("statuscolumn", statuscolumn, opts)
 
   -- use Normal instead of NormalFloat
-  vim.api.nvim_set_option_value("winhl", "Normal:Normal", opts)
+  vim.api.nvim_set_option_value("winhighlight", "NormalFloat:Normal", opts)
 
   -- Copy window options from the main window to the sticky header window
   copy_win_options({

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -170,15 +170,6 @@ function View:_highlight_field(lnum, column_index, offset, field)
     hl_group = "CsvViewCol" .. (column_index - 1) % 9,
     end_col = offset + field.len,
   })
-
-  -- highlight header
-  -- The array format of hl_group is not supported in neovim 0.10, so the header line highlight is separate.
-  if lnum == self.opts.view.header_lnum then
-    self:_add_extmark(lnum, offset, {
-      hl_group = "CsvViewHeader",
-      end_col = offset + field.len,
-    })
-  end
 end
 
 --- Render field in line
@@ -228,6 +219,11 @@ function View:_render_line(lnum)
   if line.is_comment then
     self:_highlight_comment(lnum)
     return
+  end
+
+  -- highlight header
+  if lnum == self.opts.view.header_lnum then
+    self:_add_extmark(lnum, 0, { line_hl_group = "CsvViewHeaderLine" })
   end
 
   -- render fields

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -3,13 +3,14 @@ local buf = require("csvview.buf")
 local config = require("csvview.config")
 local errors = require("csvview.errors")
 
---- Get end column of line
----@param winid integer window id
+--- Get eol column.
+--- Must have the buffer open in the current tab page.
+---@param bufnr integer buffer number
 ---@param lnum integer 1-indexed lnum
 ---@return integer 0-indexed column
-local function end_col(winid, lnum)
+local function get_eol_col(bufnr, lnum)
   ---@diagnostic disable-next-line: assign-type-mismatch
-  return vim.fn.col({ lnum, "$" }, winid) - 1
+  return vim.fn.col({ lnum, "$" }, vim.fn.bufwinid(bufnr)) - 1
 end
 
 --- @class CsvView.View
@@ -42,125 +43,41 @@ function View:new(bufnr, metrics, opts, on_dispose)
   return setmetatable(obj, self)
 end
 
---- Add extmark to buffer
----@param line integer 1-based lnum
----@param col integer 0-based column
----@param opts vim.api.keyset.set_extmark
-function View:_add_extmark(line, col, opts)
-  -- Manage extmark per line
-  if not self._extmarks[line] then
-    self._extmarks[line] = {}
-  end
-
-  self._extmarks[line][#self._extmarks[line] + 1] =
-    vim.api.nvim_buf_set_extmark(self.bufnr, EXTMARK_NS, line - 1, col, opts)
-end
-
---- Align field to the left
----@param lnum integer 1-indexed lnum
----@param offset integer 0-indexed byte offset
----@param padding integer
----@param field CsvView.Metrics.Field
----@param border boolean
-function View:_align_left(lnum, offset, padding, field, border)
-  if padding > 0 then
-    self:_add_extmark(lnum, offset + field.len, {
-      virt_text = { { string.rep(" ", padding) } },
-      virt_text_pos = "inline",
-      right_gravity = true,
-    })
-  end
-
-  if not border then
+--- Render view
+---@param force? boolean force render even if locked
+function View:render(force)
+  if not force and self:is_locked() then
     return
   end
 
-  -- render border or highlight delimiter
-  if self.opts.view.display_mode == "border" then
-    self:_render_border(lnum, offset + field.len)
-  else
-    self:_highlight_delimiter(lnum, offset + field.len)
+  -- Clear previous rendering before re-render
+  self:clear()
+
+  -- Render with all window ranges
+  local wins = buf.tabpage_win_find(0, self.bufnr)
+  for _, winid in ipairs(wins) do
+    local top = vim.fn.line("w0", winid)
+    local bot = vim.fn.line("w$", winid)
+
+    self:_set_window_options(winid)
+    self:_render_lines(top, bot)
   end
 end
 
---- Align field to the right
----@param lnum integer 1-indexed lnum
----@param offset integer 0-indexed byte offset
----@param padding integer
----@param field CsvView.Metrics.Field
----@param border boolean
-function View:_align_right(lnum, offset, padding, field, border)
-  if padding > 0 then
-    self:_add_extmark(lnum, offset, {
-      virt_text = { { string.rep(" ", padding) } },
-      virt_text_pos = "inline",
-      right_gravity = false,
-    })
-  end
-
-  if not border then
-    return
-  end
-
-  -- render border or highlight delimiter
-  if self.opts.view.display_mode == "border" then
-    self:_render_border(lnum, offset + field.len)
-  else
-    self:_highlight_delimiter(lnum, offset + field.len)
-  end
+--- Lock view rendering
+function View:lock()
+  self._locked = true
 end
 
---- render column index header
----@param lnum integer 1-indexed lnum.render header above this line.
-function View:render_column_index_header(lnum)
-  local virt = {} --- @type string[][]
-  for i, column in ipairs(self.metrics.columns) do
-    local char = tostring(i)
-    virt[#virt + 1] = { string.rep(" ", column.max_width - #char + self.opts.view.spacing) }
-    virt[#virt + 1] = { char }
-    if i < #self.metrics.columns then
-      virt[#virt + 1] = { "," }
-    end
-  end
-  self:_add_extmark(lnum, 0, { virt_lines = { virt }, virt_lines_above = true })
+--- Unlock view rendering
+function View:unlock()
+  self._locked = false
 end
 
---- highlight delimiter char
----@param lnum integer 1-indexed lnum
----@param offset integer 0-indexed byte offset
-function View:_highlight_delimiter(lnum, offset)
-  self:_add_extmark(lnum, offset, { hl_group = "CsvViewDelimiter", end_col = offset + #self._delimiter })
-end
-
---- highlight comment line
----@param lnum integer 1-indexed lnum
----@param winid integer window id
-function View:_highlight_comment(lnum, winid)
-  self:_add_extmark(lnum, 0, { hl_group = "CsvViewComment", end_col = end_col(winid, lnum) })
-end
-
---- highlight field
----@param lnum integer 1-indexed lnum
----@param column_index integer 1-indexed column index
----@param offset integer 0-indexed byte offset
----@param field CsvView.Metrics.Field
-function View:_highlight_field(lnum, column_index, offset, field)
-  -- use built-in csv syntax highlight group.
-  -- csvCol0 ~ csvCol8
-  -- see https://github.com/neovim/neovim/blob/master/runtime/syntax/csv.vim
-  local hl_group = "csvCol" .. (column_index - 1) % 9
-  self:_add_extmark(lnum, offset, { hl_group = hl_group, end_col = offset + field.len })
-end
-
---- render table border
----@param lnum integer 1-indexed lnum
----@param offset integer 0-indexed byte offset
-function View:_render_border(lnum, offset)
-  self:_add_extmark(lnum, offset, {
-    conceal = "│",
-    end_col = offset + #self._delimiter,
-    hl_group = "CsvViewDelimiter",
-  })
+--- check if view rendering is locked
+---@return boolean
+function View:is_locked()
+  return self._locked
 end
 
 --- Clear all extmarks
@@ -181,6 +98,96 @@ function View:dispose()
   end
 end
 
+-------------------------------------------------------
+-- private methods
+-------------------------------------------------------
+
+--- Add extmark to buffer
+---@param line integer 1-based lnum
+---@param col integer 0-based column
+---@param opts vim.api.keyset.set_extmark
+function View:_add_extmark(line, col, opts)
+  -- Manage extmark per line
+  if not self._extmarks[line] then
+    self._extmarks[line] = {}
+  end
+
+  self._extmarks[line][#self._extmarks[line] + 1] =
+    vim.api.nvim_buf_set_extmark(self.bufnr, EXTMARK_NS, line - 1, col, opts)
+end
+
+--- Align field to the left
+---@param lnum integer 1-indexed lnum
+---@param offset integer 0-indexed byte offset
+---@param padding integer
+---@param field CsvView.Metrics.Field
+function View:_align_field(lnum, offset, padding, field)
+  if padding <= 0 then
+    return
+  end
+
+  local pad = { { string.rep(" ", padding) } }
+  if field.is_number then
+    -- align right
+    self:_add_extmark(lnum, offset, {
+      virt_text = pad,
+      virt_text_pos = "inline",
+      right_gravity = false,
+    })
+  else
+    -- align left
+    self:_add_extmark(lnum, offset + field.len, {
+      virt_text = pad,
+      virt_text_pos = "inline",
+      right_gravity = true,
+    })
+  end
+end
+
+--- Render delimiter char
+---@param lnum integer 1-indexed lnum
+---@param offset integer 0-indexed byte offset
+function View:_render_delimiter(lnum, offset)
+  local end_col = offset + #self._delimiter
+  if self.opts.view.display_mode == "border" then
+    self:_add_extmark(lnum, offset, {
+      hl_group = "CsvViewDelimiter",
+      end_col = end_col,
+      conceal = "│",
+    })
+  else
+    self:_add_extmark(lnum, offset, {
+      hl_group = "CsvViewDelimiter",
+      end_col = end_col,
+    })
+  end
+end
+
+--- highlight comment line
+---@param lnum integer 1-indexed lnum
+function View:_highlight_comment(lnum)
+  self:_add_extmark(lnum, 0, {
+    hl_group = "CsvViewComment",
+    end_col = get_eol_col(self.bufnr, lnum),
+  })
+end
+
+--- highlight field
+---@param lnum integer 1-indexed lnum
+---@param column_index integer 1-indexed column index
+---@param offset integer 0-indexed byte offset
+---@param field CsvView.Metrics.Field
+function View:_highlight_field(lnum, column_index, offset, field)
+  -- use built-in csv syntax highlight group.
+  -- csvCol0 ~ csvCol8
+  -- see https://github.com/neovim/neovim/blob/master/runtime/syntax/csv.vim
+  local hl_group = "csvCol" .. (column_index - 1) % 9
+  self:_add_extmark(lnum, offset, {
+    hl_group = hl_group,
+    end_col = offset + field.len,
+  })
+end
+
 --- Render field in line
 ---@param lnum integer 1-indexed lnum
 ---@param column_index 1-indexed column index
@@ -192,16 +199,15 @@ function View:_render_field(lnum, column_index, field, offset)
     return
   end
 
-  self:_highlight_field(lnum, column_index, offset, field)
-
-  -- if column is last, do not render border.
-  local render_border = column_index < #self.metrics.rows[lnum].fields
+  -- if column is last, do not render delimiter
+  local should_render_delimiter = column_index < #self.metrics.rows[lnum].fields
   local colwidth = math.max(self.metrics.columns[column_index].max_width, self.opts.view.min_column_width)
   local padding = colwidth - field.display_width + self.opts.view.spacing
-  if field.is_number then
-    self:_align_right(lnum, offset, padding, field, render_border)
-  else
-    self:_align_left(lnum, offset, padding, field, render_border)
+
+  self:_highlight_field(lnum, column_index, offset, field)
+  self:_align_field(lnum, offset, padding, field)
+  if should_render_delimiter then
+    self:_render_delimiter(lnum, offset + field.len)
   end
 end
 
@@ -214,8 +220,7 @@ end
 
 --- Render line
 ---@param lnum integer 1-indexed lnum
----@param winid integer window id
-function View:_render_line(lnum, winid)
+function View:_render_line(lnum)
   local line = self.metrics.rows[lnum]
   if not line then
     return
@@ -228,7 +233,7 @@ function View:_render_line(lnum, winid)
   end
 
   if line.is_comment then
-    self:_highlight_comment(lnum, winid)
+    self:_highlight_comment(lnum)
     return
   end
 
@@ -247,54 +252,38 @@ end
 --- `:h nvim_set_decoration_provider()` says that setting options inside the callback can lead to unexpected results.
 --- Therefore, it is set to be executed in the next tick using `vim.schedule_wrap()`.
 ---@type fun(self:CsvView.View, winid:integer )
-View._set_window_options = vim.schedule_wrap(function(self, winid)
-  if not vim.api.nvim_win_is_valid(winid) then
-    return
-  end
+View._set_window_options = vim.schedule_wrap(
+  --- @param self CsvView.View
+  --- @param winid integer
+  function(self, winid)
+    if not vim.api.nvim_win_is_valid(winid) then
+      return
+    end
 
-  if self.opts.view.display_mode == "border" then
-    vim.api.nvim_win_call(winid, function()
+    local function set_local(key, value)
+      if vim.api.nvim_get_option_value(key, { scope = "local", win = winid }) ~= value then
+        vim.api.nvim_set_option_value(key, value, { scope = "local", win = winid })
+      end
+    end
+
+    if self.opts.view.display_mode == "border" then
       -- Settings for conceal delimiter with border
-      vim.wo[winid][0].concealcursor = "nvic"
-      vim.wo[winid][0].conceallevel = 2
-    end)
+      set_local("concealcursor", "nvic")
+      set_local("conceallevel", 2)
+    end
   end
-end)
+)
 
---- Render view
+--- Render lines
 ---@param top_lnum integer 1-indexed
 ---@param bot_lnum integer 1-indexed
----@param winid integer window id
-function View:render(top_lnum, bot_lnum, winid)
-  -- https://github.com/neovim/neovim/issues/16166
-  -- self:render_column_index_header(top_lnum)
-
-  -- set window options for view
-  self:_set_window_options(winid)
-
-  --- render all fields in ranges
+function View:_render_lines(top_lnum, bot_lnum)
   for lnum = top_lnum, bot_lnum do
-    local ok, err = xpcall(self._render_line, errors.wrap_stacktrace, self, lnum, winid)
+    local ok, err = xpcall(self._render_line, errors.wrap_stacktrace, self, lnum)
     if not ok then
       errors.error_with_context(err, { lnum = lnum })
     end
   end
-end
-
---- Lock view rendering
-function View:lock()
-  self._locked = true
-end
-
---- Unlock view rendering
-function View:unlock()
-  self._locked = false
-end
-
---- check if view rendering is locked
----@return boolean
-function View:is_locked()
-  return self._locked
 end
 
 -------------------------------------------------------
@@ -341,47 +330,22 @@ function M.get(bufnr)
   return M._views[bufnr]
 end
 
---- Render view with window ranges
----@param bufnr integer
----@param view CsvView.View
-local function render_with_window_ranges(bufnr, view)
-  -- Do not render if locked
-  if view:is_locked() then
-    return
-  end
-
-  -- Clear last rendering
-  view:clear()
-
-  -- Render with all window ranges
-  local wins = vim.fn.win_findbuf(bufnr)
-  for _, winid in ipairs(wins) do
-    -- Get window range
-    local top = vim.fn.line("w0", winid)
-    local bot = vim.fn.line("w$", winid)
-
-    -- Render view
-    local ok, err = xpcall(view.render, errors.wrap_stacktrace, view, top, bot, winid)
+--- Render all views
+function M.render()
+  for _, view in pairs(M._views) do
+    local ok, err = xpcall(view.render, errors.wrap_stacktrace, view)
     if not ok then
       errors.print_structured_error("CsvView Rendering Stopped with Error", err)
-      M.detach(bufnr)
+      M.detach(view.bufnr)
     end
   end
 end
 
 --- setup view
 function M.setup()
-  -- set highlight
-  vim.api.nvim_set_hl(0, "CsvViewDelimiter", { link = "Comment", default = true })
-  vim.api.nvim_set_hl(0, "CsvViewComment", { link = "Comment", default = true })
-
-  -- set decorator
   vim.api.nvim_set_decoration_provider(EXTMARK_NS, {
     on_start = function(_, _)
-      -- Render all views
-      for bufnr, view in pairs(M._views) do
-        render_with_window_ranges(bufnr, view)
-      end
+      M.render()
       return false
     end,
   })

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -178,14 +178,20 @@ end
 ---@param offset integer 0-indexed byte offset
 ---@param field CsvView.Metrics.Field
 function View:_highlight_field(lnum, column_index, offset, field)
-  -- use built-in csv syntax highlight group.
-  -- csvCol0 ~ csvCol8
-  -- see https://github.com/neovim/neovim/blob/master/runtime/syntax/csv.vim
-  local hl_group = "csvCol" .. (column_index - 1) % 9
+  -- highlight field
   self:_add_extmark(lnum, offset, {
-    hl_group = hl_group,
+    hl_group = "CsvViewCol" .. (column_index - 1) % 9,
     end_col = offset + field.len,
   })
+
+  -- highlight header
+  -- The array format of hl_group is not supported in neovim 0.10, so the header line highlight is separate.
+  if lnum == self.opts.view.header_lnum then
+    self:_add_extmark(lnum, offset, {
+      hl_group = "CsvViewHeader",
+      end_col = offset + field.len,
+    })
+  end
 end
 
 --- Render field in line

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -3,16 +3,6 @@ local buf = require("csvview.buf")
 local config = require("csvview.config")
 local errors = require("csvview.errors")
 
---- Get eol column.
---- Must have the buffer open in the current tab page.
----@param bufnr integer buffer number
----@param lnum integer 1-indexed lnum
----@return integer 0-indexed column
-local function get_eol_col(bufnr, lnum)
-  ---@diagnostic disable-next-line: assign-type-mismatch
-  return vim.fn.col({ lnum, "$" }, vim.fn.bufwinid(bufnr)) - 1
-end
-
 --- @class CsvView.View
 --- @field public bufnr integer
 --- @field public metrics CsvView.Metrics
@@ -166,10 +156,7 @@ end
 --- highlight comment line
 ---@param lnum integer 1-indexed lnum
 function View:_highlight_comment(lnum)
-  self:_add_extmark(lnum, 0, {
-    hl_group = "CsvViewComment",
-    end_col = get_eol_col(self.bufnr, lnum),
-  })
+  self:_add_extmark(lnum, 0, { hl_group = "CsvViewComment", end_row = lnum, hl_eol = true })
 end
 
 --- highlight field


### PR DESCRIPTION
## Description

This PR enhances CSV view highlighting by introducing custom highlight groups and addressing compatibility issues and conflicts with the built-in CSV syntax.

### Added Highlight Groups

The following highlight groups have been introduced to improve CSV file readability:

Highlight Group | Link | Usage
-- | -- | --
`CsvViewHeaderLine` | - | Used for highlighting header lines
`CsvViewCol0` to `CsvViewCol8` | Linked to `csvCol0` to `csvCol8` | Used for field highlighting per column

### Implemented Fixes

1. Fallback for Neovim Versions Below 0.11 ([be9697b](https://github.com/hat0uma/csvview.nvim/pull/42/commits/be9697bcfad7ccf6b4748b815bbffa615dfa20e0))
For users running Neovim versions older than 0.11, fallback highlight definitions have been added to ensure proper rendering despite the absence of built-in CSV syntax groups.

2. Disabling Built-in Syntax Highlighting ([bdded15](https://github.com/hat0uma/csvview.nvim/pull/42/commits/bdded15a5d2901bff1f588707e962555f3fb4cd8))
To prevent conflicts with the custom CSV view highlighting, the built-in syntax highlighting is disabled during CSV view rendering. The original syntax is restored when detaching the CSV view.
