### PR TITLE
fix(view): Improve rendering performance

### DIFF
--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -98,6 +98,7 @@ function M.enable(bufnr, opts)
     keymap.register(opts)
     views.attach(bufnr, view)
     sticky_header.redraw()
+    vim.cmd([[redraw!]])
     vim.api.nvim_exec_autocmds("User", { pattern = "CsvViewAttach", data = bufnr })
   end)
 end

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -11,7 +11,7 @@ local function sync_horizontal_scroll(winid, header_winid, header_lnum)
   vim.api.nvim_win_call(header_winid, function()
     local current = vim.fn.winsaveview()
     if current.leftcol ~= win_view.leftcol or current.lnum ~= header_lnum then
-      vim.fn.winrestview({ lnum = header_lnum, leftcol = win_view.leftcol })
+      vim.fn.winrestview({ topline = header_lnum, lnum = header_lnum, leftcol = win_view.leftcol })
     end
   end)
 end
@@ -155,21 +155,6 @@ local function show_sticky_header(winid, view)
   set_sticky_header_win_options(sticky_header_winid, winid)
 end
 
---- Close header window
----@param winid integer
-local function close_sticky_header_win_if_opened(winid)
-  local header_win = M._sticky_header_wins[winid]
-  if not header_win then
-    return
-  end
-
-  -- Close
-  if vim.api.nvim_win_is_valid(header_win) then
-    vim.api.nvim_win_close(header_win, true)
-  end
-  M._sticky_header_wins[winid] = nil
-end
-
 --- Determine if the sticky header should be shown.
 ---@param winid integer
 ---@param view CsvView.View
@@ -221,6 +206,21 @@ local function get_opened_csvview(winid)
   return view
 end
 
+--- Close header window
+---@param winid integer
+function M.close_if_opened(winid)
+  local header_win = M._sticky_header_wins[winid]
+  if not header_win then
+    return
+  end
+
+  -- Close
+  if vim.api.nvim_win_is_valid(header_win) then
+    vim.api.nvim_win_close(header_win, true)
+  end
+  M._sticky_header_wins[winid] = nil
+end
+
 --- statuscolumn function for sticky header window.
 ---@param winid integer csvview attached window
 ---@return string statuscolumn
@@ -248,45 +248,9 @@ function M.redraw()
       show_sticky_header(winid, view)
       sync_horizontal_scroll(winid, M._sticky_header_wins[winid], view.opts.view.header_lnum)
     else
-      close_sticky_header_win_if_opened(winid)
+      M.close_if_opened(winid)
     end
   end
-end
-
---- Setup the sticky header feature.
-function M.setup()
-  -- Autocommands
-  local group = vim.api.nvim_create_augroup("csvview.sticky_header", {})
-  vim.api.nvim_create_autocmd({
-    "WinScrolled",
-    "CursorMoved",
-    "BufEnter",
-    "WinEnter",
-    "VimResized",
-    "WinResized",
-  }, {
-    callback = M.redraw,
-    group = group,
-  })
-  vim.api.nvim_create_autocmd("OptionSet", {
-    pattern = {
-      "number",
-      "relativenumber",
-      "numberwidth",
-      "signcolumn",
-      "foldcolumn",
-    },
-    callback = M.redraw,
-    group = group,
-  })
-
-  vim.api.nvim_create_autocmd({ "WinClosed" }, {
-    callback = function(args)
-      local winid = assert(tonumber(args.match))
-      close_sticky_header_win_if_opened(winid)
-    end,
-    group = group,
-  })
 end
 
 return M

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -255,9 +255,6 @@ end
 
 --- Setup the sticky header feature.
 function M.setup()
-  -- Highlights
-  vim.api.nvim_set_hl(0, "CsvViewStickyHeaderSeparator", { link = "CsvViewDelimiter", default = true })
-
   -- Autocommands
   local group = vim.api.nvim_create_augroup("csvview.sticky_header", {})
   vim.api.nvim_create_autocmd({
@@ -280,14 +277,6 @@ function M.setup()
       "foldcolumn",
     },
     callback = M.redraw,
-    group = group,
-  })
-  vim.api.nvim_create_autocmd("User", {
-    pattern = {
-      "CsvViewAttach",
-      "CsvViewDetach",
-    },
-    callback = vim.schedule_wrap(M.redraw),
     group = group,
   })
 

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -3,6 +3,17 @@ local buf = require("csvview.buf")
 local config = require("csvview.config")
 local errors = require("csvview.errors")
 
+--- Set local option for window
+---@param winid integer
+---@param key string
+---@param value any
+local function set_local(winid, key, value)
+  local opts = { scope = "local", win = winid }
+  if vim.api.nvim_get_option_value(key, opts) ~= value then
+    vim.api.nvim_set_option_value(key, value, opts)
+  end
+end
+
 --- @class CsvView.View
 --- @field public bufnr integer
 --- @field public metrics CsvView.Metrics
@@ -33,24 +44,30 @@ function View:new(bufnr, metrics, opts, on_dispose)
   return setmetatable(obj, self)
 end
 
---- Render view
----@param force? boolean force render even if locked
-function View:render(force)
-  if not force and self:is_locked() then
-    return
+---
+--- Render lines in the specified range.
+---
+--- This method checks if the lines are already rendered and renders them if not.
+--- If you want to force re-rendering, use the `clear()` method before calling this method.
+---
+---@param top_lnum integer 1-indexed
+---@param bot_lnum integer 1-indexed
+function View:render_lines(top_lnum, bot_lnum)
+  for lnum = top_lnum, bot_lnum do
+    local ok, err = xpcall(self._render_line, errors.wrap_stacktrace, self, lnum)
+    if not ok then
+      errors.error_with_context(err, { lnum = lnum })
+    end
   end
+end
 
-  -- Clear previous rendering before re-render
-  self:clear()
-
-  -- Render with all window ranges
-  local wins = buf.tabpage_win_find(0, self.bufnr)
-  for _, winid in ipairs(wins) do
-    local top = vim.fn.line("w0", winid)
-    local bot = vim.fn.line("w$", winid)
-
-    self:_set_window_options(winid)
-    self:_render_lines(top, bot)
+--- Setup window options
+--- @param winid integer
+function View:setup_window(winid)
+  -- Conceal delimiter-char if display_mode is border
+  if self.opts.view.display_mode == "border" then
+    set_local(winid, "concealcursor", "nvic")
+    set_local(winid, "conceallevel", 2)
   end
 end
 
@@ -211,7 +228,6 @@ function View:_render_line(lnum)
   end
 
   -- Do not render if already rendered.
-  -- Another window may have already rendered this line.
   if self:_already_rendered(lnum) then
     return
   end
@@ -237,34 +253,6 @@ function View:_render_line(lnum)
   end
 end
 
---- Set window options for view
---- @param winid integer
-function View:_set_window_options(winid)
-  local function set_local(key, value) ---@type fun(key:string, value:any)
-    local opts = { scope = "local", win = winid }
-    if vim.api.nvim_get_option_value(key, opts) ~= value then
-      vim.api.nvim_set_option_value(key, value, opts)
-    end
-  end
-
-  if self.opts.view.display_mode == "border" then
-    set_local("concealcursor", "nvic")
-    set_local("conceallevel", 2)
-  end
-end
-
---- Render lines
----@param top_lnum integer 1-indexed
----@param bot_lnum integer 1-indexed
-function View:_render_lines(top_lnum, bot_lnum)
-  for lnum = top_lnum, bot_lnum do
-    local ok, err = xpcall(self._render_line, errors.wrap_stacktrace, self, lnum)
-    if not ok then
-      errors.error_with_context(err, { lnum = lnum })
-    end
-  end
-end
-
 -------------------------------------------------------
 -- module exports
 -------------------------------------------------------
@@ -284,6 +272,11 @@ function M.attach(bufnr, view)
     return
   end
   M._views[bufnr] = view
+
+  -- Setup window options
+  for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+    view:setup_window(winid)
+  end
 end
 
 --- detach view for buffer
@@ -306,17 +299,6 @@ end
 function M.get(bufnr)
   bufnr = buf.resolve_bufnr(bufnr)
   return M._views[bufnr]
-end
-
---- Render all views
-function M.render()
-  for _, view in pairs(M._views) do
-    local ok, err = xpcall(view.render, errors.wrap_stacktrace, view)
-    if not ok then
-      errors.print_structured_error("CsvView Rendering Stopped with Error", err)
-      M.detach(view.bufnr)
-    end
-  end
 end
 
 M.View = View


### PR DESCRIPTION
This PR addresses the high CPU load issue observed when the sticky header is active. The problem was caused by the continuous triggering of `nvim_set_decoration_provider()`'s `on_start` callback, which forces a complete re-render of all views whenever the sticky header is displayed.

To resolve this, the rendering process has been modified as follows:

- When metrics change, only the affected view is re-rendered.
- When metrics remain unchanged, the `on_win` callback of `nvim_set_decoration_provider` is used to render only the visible range, targeting only the lines that have not yet been rendered.

Fixes #43 