### PR TITLE
refactor: Refactor parser

### DIFF
--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -292,28 +292,4 @@ function M.setup(opts)
   M.options = vim.tbl_deep_extend("force", M.defaults, opts or {})
 end
 
---- Resolve delimiter character
----@param opts CsvView.InternalOptions
----@param bufnr integer
----@return string
-function M.resolve_delimiter(opts, bufnr)
-  local delim = opts.parser.delimiter
-  ---@diagnostic disable-next-line: no-unknown
-  local char
-  if type(delim) == "function" then
-    char = delim(bufnr)
-  end
-
-  if type(delim) == "table" then
-    char = delim.ft[vim.bo.filetype] or delim.default
-  end
-
-  if type(delim) == "string" then
-    char = delim
-  end
-
-  assert(type(char) == "string", string.format("unknown delimiter type: %s", type(char)))
-  return char
-end
-
 return M

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -6,6 +6,7 @@ local sticky_header = require("csvview.sticky_header")
 local views = require("csvview.view")
 
 local CsvViewMetrics = require("csvview.metrics")
+local CsvViewParser = require("csvview.parser")
 local buf = require("csvview.buf")
 local config = require("csvview.config")
 local keymap = require("csvview.keymap")
@@ -32,7 +33,8 @@ function M.enable(bufnr, opts)
 
   -- Create a new CsvView instance
   local on_detach --- @type fun()
-  local metrics = CsvViewMetrics:new(bufnr, opts)
+  local parser = CsvViewParser:new(bufnr, opts)
+  local metrics = CsvViewMetrics:new(bufnr, opts, parser)
   local view = CsvView:new(bufnr, metrics, opts, function() -- on detach
     on_detach()
   end)

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -62,7 +62,13 @@ function M.enable(bufnr, opts)
         -- Handle normal buffer update events
         -- TODO: Process the case where the next update comes before the current update is completed
         view:lock()
-        metrics:update(first, last, last_updated, function()
+        metrics:update(first, last, last_updated, function(err)
+          if err then
+            vim.notify("csvview: failed to update metrics: " .. err, vim.log.levels.ERROR)
+            M.disable(bufnr)
+            return
+          end
+
           view:unlock()
           view:clear()
         end)
@@ -73,7 +79,13 @@ function M.enable(bufnr, opts)
       view:clear()
       metrics:clear()
       view:lock()
-      metrics:compute_buffer(function()
+      metrics:compute_buffer(function(err)
+        if err then
+          vim.notify("csvview: failed to compute metrics: " .. err, vim.log.levels.ERROR)
+          M.disable(bufnr)
+          return
+        end
+
         view:unlock()
       end)
     end,
@@ -92,7 +104,12 @@ function M.enable(bufnr, opts)
   end
 
   -- Calculate metrics and attach view.
-  metrics:compute_buffer(function()
+  metrics:compute_buffer(function(err)
+    if err then
+      vim.notify("csvview: failed to compute metrics: " .. err, vim.log.levels.ERROR)
+      return
+    end
+
     -- disable builtin syntax highlighting.
     -- NOTE: This is necessary to prevent syntax highlighting from interfering with the custom highlighting of the view.
     vim.bo[bufnr].syntax = ""

--- a/lua/csvview/metrics.lua
+++ b/lua/csvview/metrics.lua
@@ -8,7 +8,6 @@ local nop = function() end
 --- @field public columns CsvView.Metrics.Column[]
 --- @field private _bufnr integer
 --- @field private _opts CsvView.InternalOptions
---- @field private _delimiter_len integer
 local CsvViewMetrics = {}
 
 --- @class CsvView.Metrics.Row
@@ -37,7 +36,6 @@ function CsvViewMetrics:new(bufnr, opts)
   obj._opts = opts
   obj.rows = {}
   obj.columns = {}
-  obj._delimiter_len = #config.resolve_delimiter(opts, bufnr)
 
   return setmetatable(obj, self)
 end
@@ -142,7 +140,6 @@ end
 ---@param row_idx integer row index(1-indexed)
 ---@param byte integer byte position in the row
 ---@return integer col_idx 1-indexed column index
----@return integer offset byte offset of the column
 function CsvViewMetrics:byte_to_col_idx(row_idx, byte)
   local row = self.rows[row_idx]
   if not row then
@@ -157,12 +154,12 @@ function CsvViewMetrics:byte_to_col_idx(row_idx, byte)
   end
 
   for i, field in ipairs(row.fields) do
-    if byte < (field.offset + field.len + self._delimiter_len) then
-      return i, field.offset
+    if byte < field.offset then
+      return i - 1
     end
   end
 
-  return #row.fields, row.fields[#row.fields].offset
+  return #row.fields
 end
 
 --- Compute metrics

--- a/lua/csvview/metrics.lua
+++ b/lua/csvview/metrics.lua
@@ -1,4 +1,3 @@
-local config = require("csvview.config")
 local parser = require("csvview.parser")
 
 local nop = function() end

--- a/lua/csvview/metrics.lua
+++ b/lua/csvview/metrics.lua
@@ -52,7 +52,7 @@ function CsvViewMetrics:clear()
 end
 
 --- Compute metrics for the entire buffer
----@param on_end fun()? callback for when the update is complete
+---@param on_end fun(err:string|nil)? callback for when the update is complete
 function CsvViewMetrics:compute_buffer(on_end)
   on_end = on_end or nop
   self:_compute_metrics(nil, nil, {}, on_end)
@@ -72,7 +72,7 @@ end
 ---@param first integer first line number
 ---@param prev_last integer previous last line
 ---@param last integer current last line
----@param on_end fun()? callback for when the update is complete
+---@param on_end fun(err:string|nil)? callback for when the update is complete
 function CsvViewMetrics:update(first, prev_last, last, on_end)
   on_end = on_end or nop
 
@@ -167,7 +167,7 @@ end
 ---@param startlnum integer? if present, compute only specified range
 ---@param endlnum integer? if present, compute only specified range
 ---@param recalculate_columns table<integer,boolean> recalculate specified columns
----@param on_end fun() callback for when the update is complete
+---@param on_end fun(err:string|nil) callback for when the update is complete
 function CsvViewMetrics:_compute_metrics(startlnum, endlnum, recalculate_columns, on_end)
   -- Parse specified range and update metrics.
   self._parser:parse_lines({
@@ -179,7 +179,12 @@ function CsvViewMetrics:_compute_metrics(startlnum, endlnum, recalculate_columns
       self:_mark_recalculation_on_decrease_fields(lnum, prev_row, recalculate_columns)
       self:_adjust_column_metrics_for_row(lnum, recalculate_columns)
     end,
-    on_end = function()
+    on_end = function(err)
+      if err then
+        on_end(err)
+        return
+      end
+
       -- Recalculate column metrics if necessary
       -- vim.print("recalculate_columns", recalculate_columns)
       for col_idx, _ in pairs(recalculate_columns) do

--- a/lua/csvview/util.lua
+++ b/lua/csvview/util.lua
@@ -54,11 +54,11 @@ function M.get_cursor(bufnr)
   end
 
   -- Convert the byte position to a column index
-  local col_idx, offset = view.metrics:byte_to_col_idx(lnum, col_byte)
+  local col_idx = view.metrics:byte_to_col_idx(lnum, col_byte)
 
   local field = row.fields[col_idx]
-  local offset_in_field = col_byte - offset
-  local text = vim.api.nvim_buf_get_text(bufnr, lnum - 1, offset, lnum - 1, offset + field.len, {})[1]
+  local offset_in_field = col_byte - field.offset
+  local text = vim.api.nvim_buf_get_text(bufnr, lnum - 1, field.offset, lnum - 1, field.offset + field.len, {})[1]
 
   -- Determine the anchor state of the cursor within this field
   ---@type CsvView.CursorAnchor

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -1,6 +1,5 @@
 local EXTMARK_NS = vim.api.nvim_create_namespace("csv_extmark")
 local buf = require("csvview.buf")
-local config = require("csvview.config")
 local errors = require("csvview.errors")
 
 --- Set local option for window

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -21,7 +21,6 @@ end
 --- @field private _extmarks table<integer,integer[]> 1-based line -> extmark ids
 --- @field private _on_dispose function? called when view is disposed
 --- @field private _locked boolean
---- @field private _delimiter string
 local View = {}
 
 --- create new view
@@ -40,7 +39,6 @@ function View:new(bufnr, metrics, opts, on_dispose)
   obj._extmarks = {}
   obj._on_dispose = on_dispose
   obj._locked = false
-  obj._delimiter = config.resolve_delimiter(opts, bufnr)
   return setmetatable(obj, self)
 end
 
@@ -125,10 +123,9 @@ end
 
 --- Align field to the left
 ---@param lnum integer 1-indexed lnum
----@param offset integer 0-indexed byte offset
 ---@param padding integer
 ---@param field CsvView.Metrics.Field
-function View:_align_field(lnum, offset, padding, field)
+function View:_align_field(lnum, padding, field)
   if padding <= 0 then
     return
   end
@@ -136,14 +133,14 @@ function View:_align_field(lnum, offset, padding, field)
   local pad = { { string.rep(" ", padding) } }
   if field.is_number then
     -- align right
-    self:_add_extmark(lnum, offset, {
+    self:_add_extmark(lnum, field.offset, {
       virt_text = pad,
       virt_text_pos = "inline",
       right_gravity = false,
     })
   else
     -- align left
-    self:_add_extmark(lnum, offset + field.len, {
+    self:_add_extmark(lnum, field.offset + field.len, {
       virt_text = pad,
       virt_text_pos = "inline",
       right_gravity = true,
@@ -153,9 +150,11 @@ end
 
 --- Render delimiter char
 ---@param lnum integer 1-indexed lnum
----@param offset integer 0-indexed byte offset
-function View:_render_delimiter(lnum, offset)
-  local end_col = offset + #self._delimiter
+---@param field CsvView.Metrics.Field
+---@param next_field CsvView.Metrics.Field
+function View:_render_delimiter(lnum, field, next_field)
+  local offset = field.offset + field.len
+  local end_col = next_field.offset
   if self.opts.view.display_mode == "border" then
     self:_add_extmark(lnum, offset, {
       hl_group = "CsvViewDelimiter",
@@ -179,13 +178,12 @@ end
 --- highlight field
 ---@param lnum integer 1-indexed lnum
 ---@param column_index integer 1-indexed column index
----@param offset integer 0-indexed byte offset
 ---@param field CsvView.Metrics.Field
-function View:_highlight_field(lnum, column_index, offset, field)
+function View:_highlight_field(lnum, column_index, field)
   -- highlight field
-  self:_add_extmark(lnum, offset, {
+  self:_add_extmark(lnum, field.offset, {
     hl_group = "CsvViewCol" .. (column_index - 1) % 9,
-    end_col = offset + field.len,
+    end_col = field.offset + field.len,
   })
 end
 
@@ -193,22 +191,21 @@ end
 ---@param lnum integer 1-indexed lnum
 ---@param column_index 1-indexed column index
 ---@param field CsvView.Metrics.Field
----@param offset integer 0-indexed byte offset
-function View:_render_field(lnum, column_index, field, offset)
+function View:_render_field(lnum, column_index, field)
   if not self.metrics.columns[column_index] then
     -- not computed yet.
     return
   end
 
   -- if column is last, do not render delimiter
-  local should_render_delimiter = column_index < #self.metrics.rows[lnum].fields
   local colwidth = math.max(self.metrics.columns[column_index].max_width, self.opts.view.min_column_width)
   local padding = colwidth - field.display_width + self.opts.view.spacing
 
-  self:_highlight_field(lnum, column_index, offset, field)
-  self:_align_field(lnum, offset, padding, field)
-  if should_render_delimiter then
-    self:_render_delimiter(lnum, offset + field.len)
+  self:_highlight_field(lnum, column_index, field)
+  self:_align_field(lnum, padding, field)
+  local next_field = self.metrics.rows[lnum].fields[column_index + 1]
+  if next_field then
+    self:_render_delimiter(lnum, field, next_field)
   end
 end
 
@@ -243,13 +240,11 @@ function View:_render_line(lnum)
   end
 
   -- render fields
-  local offset = 0
   for column_index, field in ipairs(line.fields) do
-    local ok, err = xpcall(self._render_field, errors.wrap_stacktrace, self, lnum, column_index, field, offset)
+    local ok, err = xpcall(self._render_field, errors.wrap_stacktrace, self, lnum, column_index, field)
     if not ok then
       errors.error_with_context(err, { lnum = lnum, column_index = column_index })
     end
-    offset = offset + field.len + #self._delimiter
   end
 end
 

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -204,7 +204,7 @@ local cases = {
   },
   {
     it = "should ignore comment lines",
-    opts = { parser = { comments = { "#" } } },
+    opts = { parser = { async_chunksize = 4, comments = { "#" } } },
     lines = {
       "a,b,c,d,e,,",
       "# this is a comment",
@@ -350,6 +350,7 @@ describe("CsvViewParser", function()
 
       coroutine.yield()
       vim.api.nvim_buf_delete(bufnr, { force = true })
+      assert.are.same(#case.expected, #results)
       for i = 1, #results do
         assert.are.same(case.expected[i].is_comment, results[i].is_comment)
         assert.are.same(case.expected[i].fields, results[i].fields)

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -1,187 +1,359 @@
 ---@diagnostic disable: await-in-sync
 
+local CsvViewParser = require("csvview.parser")
 local config = require("csvview.config")
-local p = require("csvview.parser")
 
-describe("parser", function()
-  config.setup()
-
-  local quote_char = '"'
-  local quote_char_byte = string.byte(quote_char)
-
-  describe("_parse_line", function()
-    local opts = config.get({ parser = { delimiter = "," } })
-    local delimiter = p._create_delimiter_policy(opts, 0)
-
-    it("line without empty fields", function()
-      assert.are.same(
-        { { 1, "abc" }, { 5, "de" }, { 8, "f" }, { 10, "g" }, { 12, "h" } },
-        p._parse_line("abc,de,f,g,h", delimiter, quote_char_byte)
-      )
-    end)
-
-    it("should works for line includes empty fields", function()
-      assert.are.same(
-        { { 1, "abc" }, { 5, "de" }, { 8, "" }, { 9, "g" }, { 11, "h" } },
-        p._parse_line("abc,de,,g,h", delimiter, quote_char_byte)
-      )
-      assert.are.same(
-        { { 1, "abc" }, { 5, "de" }, { 8, "f" }, { 10, "g" }, { 12, "" } },
-        p._parse_line("abc,de,f,g,", delimiter, quote_char_byte)
-      )
-      assert.are.same(
-        { { 1, "" }, { 2, "abc" }, { 6, "de" }, { 9, "f" }, { 11, "g" } },
-        p._parse_line(",abc,de,f,g", delimiter, quote_char_byte)
-      )
-      assert.are.same(
-        { { 1, "abc" }, { 5, "f" }, { 7, "g" }, { 9, "" }, { 10, "" } },
-        p._parse_line("abc,f,g,,", delimiter, quote_char_byte)
-      )
-    end)
-
-    it("empty line", function()
-      assert.are.same({}, p._parse_line("", delimiter, quote_char_byte))
-    end)
-    it("should works for line includes quoted comma.", function()
-      assert.are.same(
-        { { 1, "abc" }, { 5, "de" }, { 8, '"f,g"' }, { 14, "h" } },
-        p._parse_line('abc,de,"f,g",h', delimiter, quote_char_byte)
-      )
-    end)
-    it("handles fields with missing closing quotes", function()
-      assert.are.same(
-        { { 1, "abc" }, { 5, "de" }, { 8, '"f,g,h' } },
-        p._parse_line('abc,de,"f,g,h', delimiter, quote_char_byte)
-      )
-    end)
-    it("should work for line including single quoted comma.", function()
-      local single_quote_char = "'"
-      local single_quote_char_byte = string.byte(single_quote_char)
-      assert.are.same(
-        { { 1, "abc" }, { 5, "de" }, { 8, "'f,g'" }, { 14, "h" } },
-        p._parse_line("abc,de,'f,g',h", delimiter, single_quote_char_byte)
-      )
-    end)
-
-    it("parses tab-delimited lines correctly", function()
-      local _opts = config.get({ parser = { delimiter = "\t" } })
-      local _delimiter = p._create_delimiter_policy(_opts, 0)
-      assert.are.same(
-        { { 1, "abc" }, { 5, "de" }, { 8, "f" }, { 10, "g" }, { 12, "h" } },
-        p._parse_line("abc\tde\tf\tg\th", _delimiter, quote_char_byte)
-      )
-    end)
-
-    it("parses multi-character delimiter correctly", function()
-      local _opts = config.get({ parser = { delimiter = "|!|!|" } })
-      local _delimiter = p._create_delimiter_policy(_opts, 0)
-      assert.are.same(
-        { { 1, "abc" }, { 9, "de" }, { 16, "f" }, { 22, "g" }, { 28, "h" } },
-        p._parse_line("abc|!|!|de|!|!|f|!|!|g|!|!|h", _delimiter, quote_char_byte)
-      )
-    end)
-  end)
-
-  describe("iter_lines_async", function()
-    it("should parse all lines when no range is specified", function()
-      local co = coroutine.running()
-      local lines = {
-        "a,b,c,d,e,,",
-        "",
-        "m,n",
-      }
-      local expected = {
-        { { 1, "a" }, { 3, "b" }, { 5, "c" }, { 7, "d" }, { 9, "e" }, { 11, "" }, { 12, "" } },
-        {},
-        { { 1, "m" }, { 3, "n" } },
-      }
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-
-      local actual = {}
-      local opts = config.get({ parser = { async_chunksize = 1, delimiter = "," } })
-      p.iter_lines_async(buf, nil, nil, {
-        on_line = function(_, _, line)
-          table.insert(actual, line)
-        end,
-        on_end = vim.schedule_wrap(function()
-          assert.are.same(expected, actual)
-          coroutine.resume(co)
-        end),
-      }, opts)
-
-      coroutine.yield()
-    end)
-    it("should parse only the specified range", function()
-      local co = coroutine.running()
-      local lines = {
-        "a,b,c,d,e,,",
-        "f,g,h,i,j,k,l",
-        "",
-        "m,n",
-      }
-      local startlnum = 2
-      local endlnum = 3
-      local expected = {
-        { { 1, "f" }, { 3, "g" }, { 5, "h" }, { 7, "i" }, { 9, "j" }, { 11, "k" }, { 13, "l" } },
-        {},
-      }
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-
-      local actual = {}
-      p.iter_lines_async(buf, startlnum, endlnum, {
-        on_line = function(_, _, line)
-          table.insert(actual, line)
-        end,
-        on_end = vim.schedule_wrap(function()
-          assert.are.same(expected, actual)
-          coroutine.resume(co)
-        end),
-      }, config.defaults)
-
-      coroutine.yield()
-    end)
-
-    it("should ignore comment lines", function()
-      local co = coroutine.running()
-      local lines = {
-        "a,b,c,d,e,,",
-        "# this is a comment",
-        "f,g,h,i,j,k,l",
-        "",
-        "m,n",
-      }
-      local expected = {
-        {
-          is_comment = false,
-          fields = { { 1, "a" }, { 3, "b" }, { 5, "c" }, { 7, "d" }, { 9, "e" }, { 11, "" }, { 12, "" } },
+--- test cases for the CSV parser
+---@type {
+---  it: string,
+---  opts?: CsvView.Options,
+---  lines: string[],
+---  startlnum: integer?,
+---  endlnum: integer?,
+---  max_lookahead?: integer,
+---  expected: {
+---    is_comment: boolean?,
+---    fields: CsvView.Parser.FieldInfo[],
+---  }[],
+--- }[]
+local cases = {
+  {
+    it = "should parse line without empty fields",
+    lines = { "abc,de,f,g,h" },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "de" },
+          { start_pos = 8, text = "f" },
+          { start_pos = 10, text = "g" },
+          { start_pos = 12, text = "h" },
         },
-        { is_comment = true, fields = {} },
-        {
-          is_comment = false,
-          fields = { { 1, "f" }, { 3, "g" }, { 5, "h" }, { 7, "i" }, { 9, "j" }, { 11, "k" }, { 13, "l" } },
+      },
+    },
+  },
+  {
+    it = "should parse line with empty fields",
+    lines = {
+      "abc,de,,g,h",
+      "abc,de,f,g,",
+      ",abc,de,f,g",
+      "abc,f,g,,",
+    },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "de" },
+          { start_pos = 8, text = "" },
+          { start_pos = 9, text = "g" },
+          { start_pos = 11, text = "h" },
         },
-        { is_comment = false, fields = {} },
-        { is_comment = false, fields = { { 1, "m" }, { 3, "n" } } },
-      }
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "de" },
+          { start_pos = 8, text = "f" },
+          { start_pos = 10, text = "g" },
+          { start_pos = 12, text = "" },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "" },
+          { start_pos = 2, text = "abc" },
+          { start_pos = 6, text = "de" },
+          { start_pos = 9, text = "f" },
+          { start_pos = 11, text = "g" },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "f" },
+          { start_pos = 7, text = "g" },
+          { start_pos = 9, text = "" },
+          { start_pos = 10, text = "" },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse empty line",
+    lines = { "" },
+    expected = {
+      {
+        is_comment = false,
+        fields = {},
+      },
+    },
+  },
+  {
+    it = "should parse line with quoted comma",
+    lines = { 'abc,de,"f,g",h' },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "de" },
+          { start_pos = 8, text = '"f,g"' },
+          { start_pos = 14, text = "h" },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse line with missing closing quotes",
+    lines = { 'abc,de,"f,g,h' },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "de" },
+          { start_pos = 8, text = '"f,g,h' },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse line with single quoted comma",
+    opts = { parser = { quote_char = "'" } },
+    lines = { "abc,de,'f,g',h" },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "de" },
+          { start_pos = 8, text = "'f,g'" },
+          { start_pos = 14, text = "h" },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse tab-delimited line",
+    opts = { parser = { delimiter = "\t" } },
+    lines = { "abc\tde\tf\tg\th" },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 5, text = "de" },
+          { start_pos = 8, text = "f" },
+          { start_pos = 10, text = "g" },
+          { start_pos = 12, text = "h" },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse line with multi-character delimiter",
+    opts = { parser = { delimiter = "|!|!|" } },
+    lines = { "abc|!|!|de|!|!|f|!|!|g|!|!|h" },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "abc" },
+          { start_pos = 9, text = "de" },
+          { start_pos = 16, text = "f" },
+          { start_pos = 22, text = "g" },
+          { start_pos = 28, text = "h" },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse only the specified range",
+    startlnum = 2,
+    endlnum = 3,
+    lines = {
+      "a,b,c,d,e,,",
+      "f,g,h,i,j,k,l",
+      "",
+      "m,n",
+    },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "f" },
+          { start_pos = 3, text = "g" },
+          { start_pos = 5, text = "h" },
+          { start_pos = 7, text = "i" },
+          { start_pos = 9, text = "j" },
+          { start_pos = 11, text = "k" },
+          { start_pos = 13, text = "l" },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {},
+      },
+    },
+  },
+  {
+    it = "should ignore comment lines",
+    opts = { parser = { comments = { "#" } } },
+    lines = {
+      "a,b,c,d,e,,",
+      "# this is a comment",
+      "f,g,h,i,j,k,l",
+      "",
+      "m,n",
+    },
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "a" },
+          { start_pos = 3, text = "b" },
+          { start_pos = 5, text = "c" },
+          { start_pos = 7, text = "d" },
+          { start_pos = 9, text = "e" },
+          { start_pos = 11, text = "" },
+          { start_pos = 12, text = "" },
+        },
+      },
+      {
+        is_comment = true,
+        fields = {},
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "f" },
+          { start_pos = 3, text = "g" },
+          { start_pos = 5, text = "h" },
+          { start_pos = 7, text = "i" },
+          { start_pos = 9, text = "j" },
+          { start_pos = 11, text = "k" },
+          { start_pos = 13, text = "l" },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {},
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "m" },
+          { start_pos = 3, text = "n" },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse multi-line quoted fields",
+    lines = {
+      '"123","This is a',
+      "multiline comment",
+      'spanning several lines.",ok',
+    },
+    max_lookahead = 20,
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = '"123"' },
+          { start_pos = 7, text = { '"This is a', "multiline comment", 'spanning several lines."' } },
+          { start_pos = 26, text = "ok" },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse multi-line quoted fields with empty lines",
+    lines = {
+      '"header1","header2"',
+      '"value1","multi',
+      "",
+      'line value2"',
+    },
+    max_lookahead = 20,
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = '"header1"' },
+          { start_pos = 11, text = '"header2"' },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = '"value1"' },
+          { start_pos = 10, text = { '"multi', "", 'line value2"' } },
+        },
+      },
+    },
+  },
+  {
+    it = "should parse quoted fields with escaped quotes",
+    lines = {
+      '"header1","header2"',
+      '"value1","multi ""quoted"" value2"',
+    },
+    max_lookahead = 20,
+    expected = {
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = '"header1"' },
+          { start_pos = 11, text = '"header2"' },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = '"value1"' },
+          { start_pos = 10, text = '"multi ""quoted"" value2"' },
+        },
+      },
+    },
+  },
+}
 
-      local opts = config.get({ parser = { comments = { "#" } } })
+describe("CsvViewParser", function()
+  config.setup({ parser = { async_chunksize = 1 } })
 
-      local actual = {}
-      p.iter_lines_async(buf, nil, nil, {
-        on_line = function(_, is_comment, line)
-          table.insert(actual, { is_comment = is_comment, fields = line })
-        end,
+  for _, case in ipairs(cases) do
+    it(case.it, function()
+      local opts = config.get(case.opts)
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local parser = CsvViewParser:new(bufnr, opts)
+      parser._max_lookahead = case.max_lookahead or 0
+
+      vim.api.nvim_buf_set_lines(bufnr, 0, #case.lines, false, case.lines)
+
+      local thread = coroutine.running()
+      local results = {} ---@type { is_comment: boolean?, fields: CsvView.Parser.FieldInfo[] }[]
+      parser:parse_lines({
         on_end = vim.schedule_wrap(function()
-          assert.are.same(expected, actual)
-          coroutine.resume(co)
+          coroutine.resume(thread)
         end),
-      }, opts)
+        on_line = function(lnum, is_comment, fields)
+          table.insert(results, { is_comment = is_comment, fields = fields })
+        end,
+      }, case.startlnum, case.endlnum)
 
       coroutine.yield()
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+      for i = 1, #results do
+        assert.are.same(case.expected[i].is_comment, results[i].is_comment)
+        assert.are.same(case.expected[i].fields, results[i].fields)
+      end
     end)
-  end)
+  end
 end)

--- a/tests/textobject_spec.lua
+++ b/tests/textobject_spec.lua
@@ -18,6 +18,7 @@ local function create_test(delimiter)
     table.concat({ "1", "XUMMW7737A", "Jane Davis", "jane.williams@example.org", "1964-03-22" }, delimiter),
     table.concat({ "# this is a comment" }, delimiter),
     table.concat({ "" }, delimiter),
+    table.concat({ "abc" }, delimiter),
   }
 
   ---@class CsvView.TextObjectCase
@@ -57,6 +58,12 @@ local function create_test(delimiter)
       cursor = { row = 4, col = 0 },
       opts = { include_delimiter = false },
       expected = "",
+    },
+    {
+      name = "select the current field with delimiter. The cursor is first and last column",
+      cursor = { row = 5, col = 0 },
+      opts = { include_delimiter = true },
+      expected = "abc",
     },
   }
   return opts, lines, cases


### PR DESCRIPTION
This pull request refactors the CSV parsing and metrics computation logic in the `csvview` plugin to improve modularity, error handling, and maintainability. The changes primarily involve moving delimiter resolution to the parser, introducing a parser class for field-level details, and enhancing error reporting during asynchronous operations.

### Refactoring and Modularization

* Removed the `resolve_delimiter` function from `config.lua` and integrated delimiter resolution into the parser module (`resolve_delimiter` is now part of `parser.lua`). This centralizes parsing logic and simplifies configuration. [[1]](diffhunk://#diff-78b9938c5bb050ff7ae41a9747a5a31d8ddcb401a6362b56fa967e47cac2781aL295-L318) [[2]](diffhunk://#diff-11501f7fc783d3e84bfea61c1693fb4677e5783f93f15d09f03f18f9d0b3d0fcL1-R59)
* Introduced the `CsvView.Parser` class to handle parsing logic, including field offsets and delimiter policies. This replaces the previous ad-hoc delimiter handling and provides a structured way to manage parsing. [[1]](diffhunk://#diff-eb3057b6ee40db3da0c4e19fe57accbe69dd10488ab2bf3d7631998c19783d2fR9) [[2]](diffhunk://#diff-11501f7fc783d3e84bfea61c1693fb4677e5783f93f15d09f03f18f9d0b3d0fcL1-R59)
* Updated `CsvView.Metrics` to use the new parser class for field-level details, removing reliance on delimiter length and simplifying field computations. [[1]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL1-R8) [[2]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cR20-L39) [[3]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL136-L147) [[4]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL214-R217)

### Enhanced Error Handling

* Added error handling to asynchronous operations (`compute_buffer` and `update`) in `metrics.lua`. Errors are now passed to callbacks and displayed using `vim.notify`, improving user feedback and debugging. [[1]](diffhunk://#diff-eb3057b6ee40db3da0c4e19fe57accbe69dd10488ab2bf3d7631998c19783d2fL63-R71) [[2]](diffhunk://#diff-eb3057b6ee40db3da0c4e19fe57accbe69dd10488ab2bf3d7631998c19783d2fL74-R88) [[3]](diffhunk://#diff-eb3057b6ee40db3da0c4e19fe57accbe69dd10488ab2bf3d7631998c19783d2fL93-R112) [[4]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL56-R55) [[5]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL76-R75) [[6]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL189-R187)

### Code Simplification

* Simplified field offset and length calculations in `Metrics` by leveraging the new `FieldInfo` structure from the parser. This removes the need for manual delimiter length calculations. [[1]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL136-L147) [[2]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL161-R173)
* Removed unused code and redundant logic, such as the delimiter length field in `Metrics` and the `is_comment_line` function. [[1]](diffhunk://#diff-4d6aa7d65e709955f308136b8331890a02993369a614c3994bd9f6a036b8ad7cL1-R8) [[2]](diffhunk://#diff-11501f7fc783d3e84bfea61c1693fb4677e5783f93f15d09f03f18f9d0b3d0fcL1-R59)