### PR TITLE
refactor(metrics): encapsulate rows/cols via row() & column() accessors

### DIFF
--- a/lua/csvview/metrics.lua
+++ b/lua/csvview/metrics.lua
@@ -1,16 +1,46 @@
 local nop = function() end
 
+--- @class CsvView.Metrics.Row
+--- @field is_comment boolean
+--- @field fields CsvView.Metrics.Field[]
+local CsvViewMetricsRow = {}
+
+--- Create a new CsvView.Metrics.Row instance
+---@param is_comment boolean
+---@param fields CsvView.Parser.FieldInfo[]
+---@return CsvView.Metrics.Row
+function CsvViewMetricsRow:new(is_comment, fields)
+  self.__index = self
+
+  local obj = {}
+  obj.is_comment = is_comment
+  obj.fields = fields or {}
+  setmetatable(obj, self)
+  return obj
+end
+
+--- Get field by byte offset
+---@param offset integer
+---@return integer column_idx
+---@return CsvView.Metrics.Field field
+function CsvViewMetricsRow:get_field_by_offset(offset)
+  local len = #self.fields
+  for i, field in ipairs(self.fields) do
+    if offset < field.offset then
+      return i - 1, self.fields[i - 1]
+    end
+  end
+
+  return len, self.fields[len]
+end
+
 --- @class CsvView.Metrics
---- @field public rows CsvView.Metrics.Row[]
---- @field public columns CsvView.Metrics.Column[]
+--- @field private _rows CsvView.Metrics.Row[]
+--- @field private _columns CsvView.Metrics.Column[]
 --- @field private _bufnr integer
 --- @field private _opts CsvView.InternalOptions
 --- @field private _parser CsvView.Parser
 local CsvViewMetrics = {}
-
---- @class CsvView.Metrics.Row
---- @field is_comment boolean?
---- @field fields CsvView.Metrics.Field[]
 
 --- @class CsvView.Metrics.Column
 --- @field max_width integer
@@ -34,21 +64,65 @@ function CsvViewMetrics:new(bufnr, opts, parser)
   obj._bufnr = bufnr
   obj._opts = opts
   obj._parser = parser
-  obj.rows = {}
-  obj.columns = {}
+  obj._rows = {}
+  obj._columns = {}
 
   return setmetatable(obj, self)
 end
 
 --- Clear metrics
 function CsvViewMetrics:clear()
-  for _ = 1, #self.rows do
-    table.remove(self.rows)
+  for _ = 1, #self._rows do
+    table.remove(self._rows)
   end
 
-  for _ = 1, #self.columns do
-    table.remove(self.columns)
+  for _ = 1, #self._columns do
+    table.remove(self._columns)
   end
+end
+
+---
+---Options for getting row metrics
+---
+---@class CsvView.Metrics.RowGetOpts
+---
+---1-indexed line number. `lnum` is used when `row_idx` is not specified.
+---TODO: Currently, `lnum` is same as `row_idx` because multi-line fields are not supported.
+---@field lnum integer?
+---
+---1-indexed csv row index. `row_idx` is used when `lnum` is not specified.
+---@field row_idx integer?
+---
+
+--- Get row metrics
+---@param opts CsvView.Metrics.RowGetOpts
+---@return CsvView.Metrics.Row
+function CsvViewMetrics:row(opts)
+  assert(opts, "opts is required")
+  assert(opts.lnum or opts.row_idx, "opts.lnum or opts.row_idx is required")
+  assert(not (opts.lnum and opts.row_idx), "opts.lnum and opts.row_idx are mutually exclusive")
+
+  if opts.lnum then
+    return self:_get_row_by_lnum(opts.lnum)
+  else
+    return self:_get_row_by_row_idx(opts.row_idx)
+  end
+end
+
+--- Get the number of rows
+---@return integer
+function CsvViewMetrics:row_count()
+  return #self._rows
+end
+
+--- Get column metrics
+---@param col_idx 1-indexed column index
+---@return CsvView.Metrics.Column
+function CsvViewMetrics:column(col_idx)
+  if not self._columns[col_idx] then
+    error(string.format("Column out of bounds col_idx=%d", col_idx))
+  end
+  return self._columns[col_idx]
 end
 
 --- Compute metrics for the entire buffer
@@ -92,74 +166,25 @@ function CsvViewMetrics:update(first, prev_last, last, on_end)
   self:_compute_metrics(first + 1, last, recalculate_columns, on_end)
 end
 
---- Checks if the row index is valid.
----@param row_idx integer
----@return boolean
-function CsvViewMetrics:is_valid_row(row_idx)
-  return row_idx >= 1 and row_idx <= #self.rows
+--- Get row metrics by line number
+---@param lnum integer 1-indexed line number
+---@return CsvView.Metrics.Row
+function CsvViewMetrics:_get_row_by_lnum(lnum)
+  -- TODO: This function needs to be modified if considering multi-line fields.
+  if not self._rows[lnum] then
+    error(string.format("Row out of bounds lnum=%d", lnum))
+  end
+  return self._rows[lnum]
 end
 
---- Checks if the column is empty.
----@param row_idx integer
----@param col_idx integer
----@return boolean
-function CsvViewMetrics:is_empty_field(row_idx, col_idx)
-  return self.rows[row_idx].fields[col_idx].len == 0
-end
-
---- Checks if the cursor is at the last column of the row.
----@param row_idx integer
----@param col_idx integer
----@return boolean
-function CsvViewMetrics:is_last_col(row_idx, col_idx)
-  return col_idx == #self.rows[row_idx].fields
-end
-
---- Get byte offset from column index
----@param row_idx integer row index(1-indexed)
----@param col_idx integer column index(1-indexed)
----@return integer offset field offset in bytes
----@return integer len field length in bytes
-function CsvViewMetrics:col_idx_to_byte(row_idx, col_idx)
-  local row = self.rows[row_idx]
-  if not row then
+--- Get row metrics by CSV row index
+---@param row_idx integer 1-indexed CSV row index
+---@return CsvView.Metrics.Row
+function CsvViewMetrics:_get_row_by_row_idx(row_idx)
+  if not self._rows[row_idx] then
     error(string.format("Row out of bounds row_idx=%d", row_idx))
   end
-  if row.is_comment then
-    error(string.format("Row is a comment row_idx=%d", row_idx))
-  end
-  if col_idx > #row.fields then
-    error(string.format("Column out of bounds row_idx=%d col_idx=%d", row_idx, col_idx))
-  end
-
-  local field = row.fields[col_idx]
-  return field.offset, field.len
-end
-
---- Get column index from byte position
----@param row_idx integer row index(1-indexed)
----@param byte integer byte position in the row
----@return integer col_idx 1-indexed column index
-function CsvViewMetrics:byte_to_col_idx(row_idx, byte)
-  local row = self.rows[row_idx]
-  if not row then
-    error("Row out of bounds row_idx=" .. row_idx)
-  end
-  if row.is_comment then
-    error("Row is a comment row_idx=" .. row_idx)
-  end
-
-  if #row.fields == 0 then
-    error("Row has no fields row_idx=" .. row_idx)
-  end
-
-  for i, field in ipairs(row.fields) do
-    if byte < field.offset then
-      return i - 1
-    end
-  end
-
-  return #row.fields
+  return self._rows[row_idx]
 end
 
 --- Compute metrics
@@ -172,10 +197,10 @@ function CsvViewMetrics:_compute_metrics(startlnum, endlnum, recalculate_columns
   -- Parse specified range and update metrics.
   self._parser:parse_lines({
     on_line = function(lnum, is_comment, fields)
-      local prev_row = self.rows[lnum]
+      local prev_row = self._rows[lnum]
 
       -- Update row metrics and adjust column metrics
-      self.rows[lnum] = self:_compute_metrics_for_row(is_comment, fields)
+      self._rows[lnum] = self:_compute_metrics_for_row(lnum, is_comment, fields)
       self:_mark_recalculation_on_decrease_fields(lnum, prev_row, recalculate_columns)
       self:_adjust_column_metrics_for_row(lnum, recalculate_columns)
     end,
@@ -198,18 +223,19 @@ function CsvViewMetrics:_compute_metrics(startlnum, endlnum, recalculate_columns
 end
 
 --- Compute row metrics
+---@param lnum integer line number
 ---@param is_comment boolean
 ---@param fields CsvView.Parser.FieldInfo[]
 ---@return CsvView.Metrics.Row
-function CsvViewMetrics:_compute_metrics_for_row(is_comment, fields)
+function CsvViewMetrics:_compute_metrics_for_row(lnum, is_comment, fields)
+  local row = CsvViewMetricsRow:new(is_comment, {})
   if is_comment then
-    return { is_comment = true, fields = {} }
+    return row
   end
 
   -- Compute field metrics
-  local row = { fields = {} } ---@type CsvView.Metrics.Row
   for _, field in ipairs(fields) do
-    local width = vim.fn.strdisplaywidth(field.text)
+    local width = self:_field_display_width(field)
     table.insert(row.fields, {
       offset = field.start_pos - 1,
       len = #field.text,
@@ -220,6 +246,27 @@ function CsvViewMetrics:_compute_metrics_for_row(is_comment, fields)
   return row
 end
 
+--- Get the display width of the field
+---@param field CsvView.Parser.FieldInfo
+---@return integer
+function CsvViewMetrics:_field_display_width(field)
+  local text = field.text
+  local max_width ---@type integer
+  if type(text) == "table" then
+    -- This is multi-line field. Get the width of the longest line.
+    for _, line in ipairs(text) do
+      local line_width = vim.fn.strdisplaywidth(line)
+      if line_width > max_width then
+        max_width = line_width
+      end
+    end
+  else
+    max_width = vim.fn.strdisplaywidth(text)
+  end
+
+  return max_width
+end
+
 --- Recalculate column metrics for the specified column
 ---@param col_idx integer
 function CsvViewMetrics:_recalculate_column(col_idx)
@@ -227,7 +274,7 @@ function CsvViewMetrics:_recalculate_column(col_idx)
   local max_row = nil
 
   -- Find the maximum width in the column
-  for row_idx, row in ipairs(self.rows) do
+  for row_idx, row in ipairs(self._rows) do
     if not row.is_comment and row.fields[col_idx] then
       local width = row.fields[col_idx].display_width
       if width > max_width then
@@ -239,11 +286,11 @@ function CsvViewMetrics:_recalculate_column(col_idx)
 
   if max_row then
     -- Update column metrics
-    self.columns[col_idx].max_width = max_width
-    self.columns[col_idx].max_row = max_row
+    self._columns[col_idx].max_width = max_width
+    self._columns[col_idx].max_row = max_row
   else
     -- Remove column if it is empty
-    self.columns[col_idx] = nil
+    self._columns[col_idx] = nil
   end
 end
 
@@ -263,7 +310,7 @@ function CsvViewMetrics:_mark_recalculation_on_delete(prev_last, last, recalcula
   --
   -- -> prev_last = 1, last = 0
   -- In this case, the column metrics for the first column need to be recalculated.
-  for col_idx, column in ipairs(self.columns) do
+  for col_idx, column in ipairs(self._columns) do
     if column.max_row > last and column.max_row <= prev_last then
       recalculate_columns[col_idx] = true
     end
@@ -290,11 +337,11 @@ function CsvViewMetrics:_mark_recalculation_on_decrease_fields(row_idx, prev_row
     return
   end
 
-  local row = self.rows[row_idx]
+  local row = self._rows[row_idx]
 
   for col_idx = #row.fields + 1, #prev_row.fields do
     -- Check if the column exists and if the current row was the maximum width row for this column.
-    if self.columns[col_idx] and self.columns[col_idx].max_row == row_idx then
+    if self._columns[col_idx] and self._columns[col_idx].max_row == row_idx then
       recalculate_columns[col_idx] = true
     end
   end
@@ -304,7 +351,7 @@ end
 ---@param row_idx integer row index
 ---@param recalculate_columns table<integer,boolean> recalculate columns
 function CsvViewMetrics:_adjust_column_metrics_for_row(row_idx, recalculate_columns)
-  local row = self.rows[row_idx]
+  local row = self._rows[row_idx]
 
   -- Update column metrics
   for col_idx, field in ipairs(row.fields) do
@@ -325,10 +372,10 @@ end
 ---@param col_idx integer
 ---@return CsvView.Metrics.Column
 function CsvViewMetrics:_ensure_column(col_idx)
-  if not self.columns[col_idx] then
-    self.columns[col_idx] = { max_width = 0, max_row = 0 }
+  if not self._columns[col_idx] then
+    self._columns[col_idx] = { max_width = 0, max_row = 0 }
   end
-  return self.columns[col_idx]
+  return self._columns[col_idx]
 end
 
 --- Add row placeholders
@@ -343,12 +390,12 @@ function CsvViewMetrics:_add_row_placeholders(start, num)
   -- end
   --
 
-  local len = #self.rows
+  local len = #self._rows
   for i = len, start, -1 do
-    self.rows[i + num] = self.rows[i]
+    self._rows[i + num] = self._rows[i]
   end
   for i = start, start + num - 1 do
-    self.rows[i] = { fields = {} }
+    self._rows[i] = CsvViewMetricsRow:new(false, {})
   end
 end
 
@@ -364,10 +411,10 @@ function CsvViewMetrics:_remove_rows(start, num)
   -- end
   --
 
-  local len = #self.rows
+  local len = #self._rows
   for i = start, len do
-    self.rows[i] = self.rows[i + num]
-    self.rows[i + num] = nil
+    self._rows[i] = self._rows[i + num]
+    self._rows[i + num] = nil
   end
 end
 

--- a/lua/csvview/textobject.lua
+++ b/lua/csvview/textobject.lua
@@ -30,7 +30,7 @@ function M.field(bufnr, opts)
   end
 
   -- Get the field range.
-  local row = view.metrics.rows[row_idx]
+  local row = view.metrics:row({ row_idx = row_idx })
   local field = row.fields[col_idx]
   local start_col = field.offset
   local end_col = field.offset + field.len - 1
@@ -38,7 +38,7 @@ function M.field(bufnr, opts)
   -- If `include_delimiter` is true, expand the range.
   -- NOTE: If the number of fields is 1, there is no delimiter. Ignore `include_delimiter`.
   if include_delimiter and #row.fields > 1 then
-    local is_last_col = col_idx == #view.metrics.rows[row_idx].fields
+    local is_last_col = col_idx == #row.fields
     if is_last_col then
       local prev_field = row.fields[col_idx - 1]
       start_col = prev_field.offset + prev_field.len -- include the before delimiter

--- a/lua/csvview/util.lua
+++ b/lua/csvview/util.lua
@@ -38,7 +38,7 @@ function M.get_cursor(bufnr)
 
   -- Get the (line, column) position of the cursor in the window
   local lnum, col_byte = unpack(vim.api.nvim_win_get_cursor(winid))
-  local row = view.metrics.rows[lnum]
+  local row = view.metrics:row({ lnum = lnum })
   if not row then
     error("Cursor is out of bounds.")
   end
@@ -54,9 +54,7 @@ function M.get_cursor(bufnr)
   end
 
   -- Convert the byte position to a column index
-  local col_idx = view.metrics:byte_to_col_idx(lnum, col_byte)
-
-  local field = row.fields[col_idx]
+  local col_idx, field = row:get_field_by_offset(col_byte)
   local offset_in_field = col_byte - field.offset
   local text = vim.api.nvim_buf_get_text(bufnr, lnum - 1, field.offset, lnum - 1, field.offset + field.len, {})[1]
 


### PR DESCRIPTION
`metrics.rows` and `metrics.columns`
are replaced with private variables. Use `metrics:row()` and `metrics:column()` instead.