### PR TITLE
Just field: handle case when first col is empty

### DIFF
--- a/lua/csvview/jump.lua
+++ b/lua/csvview/jump.lua
@@ -286,6 +286,9 @@ function M.field(bufnr, opts)
   else
     anchored_lnum = field.end_row
     anchored_col = field.end_col - 1
+    if anchored_col < 0 then
+      anchored_col = 0
+    end
   end
   vim.api.nvim_win_set_cursor(winid, { anchored_lnum, anchored_col })
 end


### PR DESCRIPTION
When the first column is empty, the calculated `anchored_col` becomes -1. Passing this to `vim.api.nvim_win_set_cursor` raises exception. This PR fixes this case