### PR TITLE
 fix(view): disable line wrap to prevent cursor jumping in CSV fields

### DIFF
--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -71,6 +71,8 @@ function View:setup_window(winid)
     set_local(winid, "concealcursor", "nvic")
     set_local(winid, "conceallevel", 2)
   end
+
+  set_local(winid, "wrap", false)
 end
 
 --- Lock view rendering


### PR DESCRIPTION
Prevents cursor from jumping to new lines when editing fields containing spaces by explicitly disabling line wrap in the CSV view window.

Fixes issue where users with line wrap enabled experienced unexpected cursor behavior when typing characters after spaces in CSV fields.

Related #58
Close #49 