### PR TITLE
fix(jump): correct jump to the end of an empty field

### DIFF
--- a/lua/csvview/jump.lua
+++ b/lua/csvview/jump.lua
@@ -284,7 +284,8 @@ function M.field(bufnr, opts)
     anchored_col = field.start_col
   else
     anchored_lnum = field.end_row
-    anchored_col = field.end_col - 1
+    local is_empty_field = field.start_row == field.end_row and field.start_col == field.end_col
+    anchored_col = field.end_col - (is_empty_field and 0 or 1)
     if anchored_col < 0 then
       anchored_col = 0
     end


### PR DESCRIPTION
Previously, jumping to the end of a field used `field.end_col - 1` as the column anchor.
This works for non-empty fields, but for empty fields (which contain only the delimiter), subtracting 1 moves the cursor to the delimiter of the previous field.
As a result, functions like `next_field_end` could not advance past an empty field.

This update sets the column anchor to the delimiter position itself when the destination field is empty, ensuring correct cursor movement.