### PR TITLE
fix(sticky_header): use vim.schedule for window close during BufUnload

### DIFF
--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -214,11 +214,17 @@ function M.close_header_win_for(winid)
     return
   end
 
-  -- Close
-  if vim.api.nvim_win_is_valid(header_win) then
-    pcall(vim.api.nvim_win_close, header_win, true)
-  end
   M._sticky_header_wins[winid] = nil
+  if not vim.api.nvim_win_is_valid(header_win) then
+    return
+  end
+
+  -- Close (use vim.schedule to avoid issues when called during BufUnload)
+  vim.schedule(function()
+    if vim.api.nvim_win_is_valid(header_win) then
+      pcall(vim.api.nvim_win_close, header_win, true)
+    end
+  end)
 end
 
 --- statuscolumn function for sticky header window.


### PR DESCRIPTION
## Summary

 - Fix sticky header window remaining visible after `:e!` command
 - Use `vim.schedule` to defer window close operation to avoid Neovim event callback restrictions

## Description

When reloading a buffer with :e!, the sticky header window was not being closed properly. This occurred because nvim_win_close was being called during the BufUnload event callback, where certain window operations may be restricted or silently fail.

The fix defers the window close operation using vim.schedule, ensuring it executes in the next event loop iteration when window operations are permitted.

Additionally, `M._sticky_header_wins[winid]` is now cleared before scheduling the close to prevent any race conditions.

## Test plan

- Open a CSV file with sticky header enabled
-  Scroll down so the sticky header becomes visible
- Run `:e!` to reload the buffer
- Verify the sticky header window is closed
