### PR TITLE
feat(parser): add `comment_lines` option to skip header metadata lines

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -232,8 +232,8 @@ Navigate between fields and rows with familiar keyboard shortcuts:
     -- Horizontal navigation
     jump_next_field_end = { "<Tab>", mode = { "n", "v" } },
     jump_prev_field_end = { "<S-Tab>", mode = { "n", "v" } },
-    
-    -- Vertical navigation  
+
+    -- Vertical navigation
     jump_next_row = { "<Enter>", mode = { "n", "v" } },
     jump_prev_row = { "<S-Enter>", mode = { "n", "v" } },
   },
@@ -247,8 +247,8 @@ Navigate between fields and rows with familiar keyboard shortcuts:
   keymaps = {
     -- Select field content (inner)
     textobject_field_inner = { "if", mode = { "o", "x" } },
-    
-    -- Select field including delimiter (outer)  
+
+    -- Select field including delimiter (outer)
     textobject_field_outer = { "af", mode = { "o", "x" } },
   },
 }
@@ -377,17 +377,44 @@ Jane,30,LA
 
 Only the data rows (`name,age,city`, `John,25,NYC`, `Jane,30,LA`) will be displayed in the table format.
 
+### Fixed Header Comment Lines
+
+For files with a fixed number of metadata lines at the top, use `comment_lines`:
+
+```lua
+{
+  parser = {
+    comment_lines = 2,  -- First 2 lines are always treated as comments
+  },
+}
+```
+
+This is useful for files like:
+
+```csv
+Generated: 2024-01-15
+Source: database_export
+name,age,city
+John,25,NYC
+Jane,30,LA
+```
+
+The first 2 lines will be treated as comments regardless of their content.
+
 ### Command-line Usage
 
 ```vim
 " Enable hash comments
 :CsvViewEnable comment=#
 
-" Enable C++ style comments  
+" Enable C++ style comments
 :CsvViewEnable comment=//
 
 " Enable SQL style comments
 :CsvViewEnable comment=--
+
+" Treat first N lines as comments
+:CsvViewEnable comment_lines=2
 
 " Multiple comment types (requires Lua configuration)
 ```
@@ -414,14 +441,14 @@ local jump = require("csvview.jump")
 -- Precise field navigation
 jump.field(bufnr, {
   pos = { row, col },           -- Target position (1-based)
-  mode = "absolute",            -- "absolute" or "relative" 
+  mode = "absolute",            -- "absolute" or "relative"
   anchor = "start",             -- "start" or "end"
   col_wrap = true,              -- Wrap at row boundaries
 })
 
 -- Convenience functions
 jump.next_field_start(bufnr?)   -- Like 'w' motion
-jump.prev_field_start(bufnr?)   -- Like 'b' motion  
+jump.prev_field_start(bufnr?)   -- Like 'b' motion
 jump.next_field_end(bufnr?)     -- Like 'e' motion
 jump.prev_field_end(bufnr?)     -- Like 'ge' motion
 ```
@@ -452,4 +479,3 @@ local info = util.get_cursor(bufnr)
 --   text = "field content"
 -- }
 ```
-

--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ lua require('csvview').setup()
       -- "//",
     },
 
+    --- The number of lines at the beginning of the file to treat as comments.
+    --- Lines from 1 to this number will be treated as comment lines regardless of their content.
+    --- This is useful for files that have a fixed header/metadata section at the top.
+    --- You can also specify it on the command line.
+    --- e.g:
+    --- :CsvViewEnable comment_lines=2
+    --- @type integer?
+    comment_lines = nil,
+
     --- Maximum lookahead for multi-line fields
     --- This limits how many lines ahead the parser will look when trying to find 
     --- the closing quote of a multi-line field. Setting this too high may cause

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -5,6 +5,7 @@ local M = {}
 ---@field delimiter? CsvView.Options.Parser.Delimiter
 ---@field quote_char? string
 ---@field comments? string[]
+---@field comment_lines? integer
 ---@field max_lookahead? integer
 ---@alias CsvView.Options.Parser.Delimiter string | {ft: table<string,string>, fallbacks: string[]}| fun(bufnr:integer): string
 
@@ -104,6 +105,15 @@ M.defaults = {
       -- "--",
       -- "//",
     },
+
+    --- The number of lines at the beginning of the file to treat as comments.
+    --- Lines from 1 to this number will be treated as comment lines regardless of their content.
+    --- This is useful for files that have a fixed header/metadata section at the top.
+    --- You can also specify it on the command line.
+    --- e.g:
+    --- :CsvViewEnable comment_lines=2
+    --- @type integer?
+    comment_lines = nil,
 
     --- Maximum lookahead for multi-line fields
     --- This limits how many lines ahead the parser will look when trying to find

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -27,6 +27,14 @@ local cmdline = Cmdline:new({
     end,
   },
   {
+    name = "comment_lines",
+    ---@param options CsvView.Options
+    ---@param value string
+    set = function(options, value)
+      options.parser.comment_lines = tonumber(value)
+    end,
+  },
+  {
     name = "display_mode",
     ---@param options CsvView.Options
     ---@param value string

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -269,6 +269,83 @@ local cases = {
     },
   },
   {
+    it = "should treat first N lines as comments with comment_lines option",
+    opts = { parser = { comment_lines = 2, comments = {} } },
+    lines = {
+      "File: test.csv",
+      "Date: 2024-01-01",
+      "name,age,city",
+      "John,25,New York",
+    },
+    expected = {
+      {
+        is_comment = true,
+        fields = {},
+      },
+      {
+        is_comment = true,
+        fields = {},
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "name" },
+          { start_pos = 6, text = "age" },
+          { start_pos = 10, text = "city" },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "John" },
+          { start_pos = 6, text = "25" },
+          { start_pos = 9, text = "New York" },
+        },
+      },
+    },
+  },
+  {
+    it = "should combine comment_lines and comment prefix detection",
+    opts = { parser = { comment_lines = 2, comments = { "#" } } },
+    lines = {
+      "File: test.csv",
+      "Date: 2024-01-01",
+      "# This is also a comment",
+      "name,age,city",
+      "John,25,New York",
+    },
+    expected = {
+      {
+        is_comment = true,
+        fields = {},
+      },
+      {
+        is_comment = true,
+        fields = {},
+      },
+      {
+        is_comment = true,
+        fields = {},
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "name" },
+          { start_pos = 6, text = "age" },
+          { start_pos = 10, text = "city" },
+        },
+      },
+      {
+        is_comment = false,
+        fields = {
+          { start_pos = 1, text = "John" },
+          { start_pos = 6, text = "25" },
+          { start_pos = 9, text = "New York" },
+        },
+      },
+    },
+  },
+  {
     it = "should parse multi-line quoted fields",
     lines = {
       '"123","This is a',


### PR DESCRIPTION
## Summary
- Add new `comment_lines` parser option that treats the first N lines as comments regardless of content
- Useful for CSV files with fixed header/metadata sections (e.g., file info, creation date)
- Can be combined with existing `comments` prefix detection

## Changes
- Add `comment_lines` option to `CsvView.Options.Parser`
- Create `util.create_is_comment(opts)` function to unify comment detection logic
- Refactor parser to accept comment detection function instead of comment prefixes
- Update sniffer to use the new comment detection approach

## Usage
```lua
-- In setup
require('csvview').setup({
parser = {
  comment_lines = 2,  -- Skip first 2 lines as metadata
}
})

-- Or via command line
:CsvViewEnable comment_lines=2
```

Example: 
```csv
File: data.csv
Created: 2024-01-01
name,age,city
John,25,New York
```
Setting `comment_lines = 2` will treat the first two lines as comments and parse from line 3.

Close #83 