### PR TITLE
fix allignment issue with sticky header when number option is not set

### DIFF
--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -33,7 +33,9 @@ local function get_statuscolumn_or_default(winid)
     return relnum and "%C%=%s%=%r " or "%C%=%s%=%l "
   end
 
-  return "%C%=%s%=%l "
+  local num = vim.api.nvim_get_option_value("number", { win = winid, scope = "local" }) ---@type boolean
+  local trailing_space = num and " " or ""
+  return "%C%=%s%=%l" .. trailing_space
 end
 
 --- Convert the dictionary returned by nvim_eval_statusline() into a


### PR DESCRIPTION
The sticky_header is not aligned correctly with the content when the `number` option is not set.

<img width="763" height="162" alt="image" src="https://github.com/user-attachments/assets/15ccbe9e-cc33-4d79-9097-f835382e8d9d" />


Here is the result after the fix:
<img width="763" height="162" alt="image" src="https://github.com/user-attachments/assets/38303891-3495-4ad9-acb3-7e6eb33a68f5" />

This fix also works with `number` option, and with `relativenumber` option. Same as the plugin has always done.