### PR TITLE
fix: support multi-line sticky headers when header_lnum > 1

### DIFF
--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -5,13 +5,12 @@ M._sticky_header_wins = {} --- @type table<integer,integer> winid -> sticky-head
 --- Sync the horizontal scroll of the sticky header window with the main window.
 ---@param winid integer csvview attached window
 ---@param header_winid integer sticky-header window
----@param header_lnum integer header line number
-local function sync_horizontal_scroll(winid, header_winid, header_lnum)
+local function sync_horizontal_scroll(winid, header_winid)
   local win_view = vim.api.nvim_win_call(winid, vim.fn.winsaveview) ---@type vim.fn.winsaveview.ret
   vim.api.nvim_win_call(header_winid, function()
     local current = vim.fn.winsaveview()
-    if current.leftcol ~= win_view.leftcol or current.lnum ~= header_lnum then
-      vim.fn.winrestview({ topline = header_lnum, lnum = header_lnum, leftcol = win_view.leftcol })
+    if current.leftcol ~= win_view.leftcol or current.lnum ~= 1 then
+      vim.fn.winrestview({ topline = 1, lnum = 1, leftcol = win_view.leftcol })
     end
   end)
 end
@@ -129,7 +128,7 @@ local function show_sticky_header(winid, view)
     win = winid,
     relative = "win",
     width = win_width,
-    height = 1,
+    height = view.header_lnum,
     row = 0,
     col = 0,
     focusable = false,
@@ -182,7 +181,8 @@ local function should_show_sticky_header(winid, view)
   -- Hide if the cursor overlaps with the sticky header drawing position
   -- Also hide if it overlaps with the separator.
   local cur_lnum = vim.fn.line(".", winid)
-  local header_bot_lnum = top_lnum + (view.opts.view.sticky_header.separator and 1 or 0)
+  local header_height = view.header_lnum
+  local header_bot_lnum = top_lnum + header_height - 1 + (view.opts.view.sticky_header.separator and 1 or 0)
   if cur_lnum <= header_bot_lnum then
     return false
   end
@@ -258,7 +258,7 @@ function M.redraw()
     local view = get_opened_csvview(winid)
     if view and should_show_sticky_header(winid, view) then
       show_sticky_header(winid, view)
-      sync_horizontal_scroll(winid, M._sticky_header_wins[winid], view.header_lnum)
+      sync_horizontal_scroll(winid, M._sticky_header_wins[winid])
     else
       M.close_header_win_for(winid)
     end

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -244,7 +244,7 @@ function View:_render_line(lnum)
   end
 
   -- highlight header
-  if lnum == self.header_lnum then
+  if self.header_lnum and lnum <= self.header_lnum then
     self:_add_extmark(lnum, 0, { line_hl_group = "CsvViewHeaderLine" })
   end
 


### PR DESCRIPTION
Treat header_lnum as a block size (lines 1 to header_lnum) instead of a single line index. Updated rendering highlights, floating window height, scroll syncing, and cursor overlap detection to support this.