### PR TITLE
feat(view): support padding around border characters

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -62,6 +62,7 @@ Customize the appearance of your table columns:
   view = {
     min_column_width = 5,  -- Minimum width for each column
     spacing = 2,           -- Space between columns
+    -- spacing = { left = 1, right = 1 }, -- Virtual spaces around delimiters
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -182,8 +182,11 @@ end)
     --- @type integer
     min_column_width = 5,
 
-    --- spacing between columns
-    --- @type integer
+    --- spacing between columns.
+    --- A number keeps the legacy behavior of adding that many spaces after each column.
+    --- A table can add virtual spaces around delimiters:
+    ---   spacing = { left = 1, right = 1 }
+    --- @type integer|{left:integer?, right:integer?}
     spacing = 2,
 
     --- The display method of the delimiter

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -11,11 +11,15 @@ local M = {}
 
 ---@class CsvView.Options.View
 ---@field min_column_width? integer
----@field spacing? integer
+---@field spacing? integer|CsvView.Options.View.Spacing
 ---@field display_mode? CsvView.Options.View.DisplayMode
 ---@field header_lnum? integer|false|true
 ---@field sticky_header? CsvView.Options.View.StickyHeader
 ---@alias CsvView.Options.View.DisplayMode "highlight" | "border"
+
+---@class CsvView.Options.View.Spacing
+---@field left? integer
+---@field right? integer
 
 ---@class CsvView.Options.View.StickyHeader
 ---@field enabled? boolean
@@ -127,8 +131,11 @@ M.defaults = {
     --- @type integer
     min_column_width = 5,
 
-    --- spacing between columns
-    --- @type integer
+    --- spacing between columns.
+    --- A number keeps the legacy behavior of adding that many spaces after each column.
+    --- A table can add virtual spaces around delimiters:
+    ---   spacing = { left = 1, right = 1 }
+    --- @type integer|CsvView.Options.View.Spacing
     spacing = 2,
 
     --- The display method of the delimiter

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -24,6 +24,37 @@ end
 --- @field private _locked boolean
 local View = {}
 
+--- Resolve spacing configuration.
+---@param spacing integer|CsvView.Options.View.Spacing
+---@param align_direction "right" | "left"
+---@return integer left
+---@return integer right
+local function get_spacing(spacing, align_direction)
+  if type(spacing) == "table" then
+    return spacing.left or 0, spacing.right or 0
+  end
+
+  if type(spacing) == "number" then
+    if align_direction == "right" then
+      return spacing, 0
+    else
+      return 0, spacing
+    end
+  end
+
+  error("`view.spacing` expected integer or table.")
+end
+
+--- Get column align direction
+---@param field CsvView.Metrics.Field
+---@return "right" | "left"
+local function get_align_direction(field)
+  if field.is_number then
+    return "right"
+  end
+  return "left"
+end
+
 --- create new view
 ---@param bufnr integer
 ---@param metrics CsvView.Metrics
@@ -127,31 +158,38 @@ function View:_add_extmark(line, col, opts)
     vim.api.nvim_buf_set_extmark(self.bufnr, EXTMARK_NS, line - 1, col, opts)
 end
 
---- Align field to the left
+--- Add virtual padding after the field text.
 ---@param lnum integer 1-indexed lnum
 ---@param padding integer
 ---@param field CsvView.Metrics.Field
-function View:_align_field(lnum, padding, field)
+function View:_pad_after_field(lnum, padding, field)
   if padding <= 0 then
     return
   end
 
   local pad = { { string.rep(" ", padding) } }
-  if field.is_number then
-    -- align right
-    self:_add_extmark(lnum, field.offset, {
-      virt_text = pad,
-      virt_text_pos = "inline",
-      right_gravity = false,
-    })
-  else
-    -- align left
-    self:_add_extmark(lnum, field.offset + field.len, {
-      virt_text = pad,
-      virt_text_pos = "inline",
-      right_gravity = true,
-    })
+  self:_add_extmark(lnum, field.offset + field.len, {
+    virt_text = pad,
+    virt_text_pos = "inline",
+    right_gravity = true,
+  })
+end
+
+--- Add virtual padding before the field text.
+---@param lnum integer 1-indexed lnum
+---@param padding integer
+---@param field CsvView.Metrics.Field
+function View:_pad_before_field(lnum, padding, field)
+  if padding <= 0 then
+    return
   end
+
+  local pad = { { string.rep(" ", padding) } }
+  self:_add_extmark(lnum, field.offset, {
+    virt_text = pad,
+    virt_text_pos = "inline",
+    right_gravity = false,
+  })
 end
 
 --- Render delimiter char
@@ -204,14 +242,44 @@ function View:_render_field(lnum, column_index, field)
     return
   end
 
-  -- if column is last, do not render delimiter
-  local colwidth = math.max(column.max_width, self.opts.view.min_column_width)
-  local padding = colwidth - field.display_width + self.opts.view.spacing
-
+  -- Highlight column
   if self:_field_terminated(lnum, column_index) then
     self:_highlight_field(lnum, column_index, field)
   end
-  self:_align_field(lnum, padding, field)
+
+  -- Calculate padding
+  local colwidth = math.max(column.max_width, self.opts.view.min_column_width)
+  local align_direction = get_align_direction(field)
+  local spacing_left, spacing_right = get_spacing(self.opts.view.spacing, align_direction)
+  local align_padding = colwidth - field.display_width
+
+  -- Keep the delimiter position stable across rows by splitting padding into
+  -- alignment padding and delimiter spacing.
+  --
+  -- `align_padding` is part of the column width. It goes before right-aligned
+  -- fields and after left-aligned fields, so mixed number/text rows still end
+  -- at the same delimiter column.
+  --
+  -- `spacing_left` represents the visual gap after the previous delimiter.
+  -- The first field on a line has no previous delimiter, so table-style
+  -- spacing should not add a leading gap there.
+  local before_padding = spacing_left
+  local after_padding = spacing_right
+  local is_first_field = field.offset == 0
+  if type(self.opts.view.spacing) == "table" and is_first_field then
+    before_padding = 0
+  end
+  if align_direction == "right" then
+    before_padding = before_padding + align_padding
+  else
+    after_padding = after_padding + align_padding
+  end
+
+  -- Add padding
+  self:_pad_before_field(lnum, before_padding, field)
+  self:_pad_after_field(lnum, after_padding, field)
+
+  -- if column is last, do not render delimiter
   local next_field = self.metrics:row({ lnum = lnum }):field(column_index + 1)
   if next_field then
     self:_render_delimiter(lnum, field, next_field)
@@ -301,11 +369,12 @@ end
 --- @return integer padding
 function View:_calculate_padding_for_multiline(lnum, row)
   local padding = 0
+  local spacing_left, spacing_right = get_spacing(self.opts.view.spacing, "left")
   local ranges = self.metrics:get_logical_row_fields({ lnum = lnum })
   for i = row.skipped_ncol, 1, -1 do
     local column = self.metrics:column(i)
     if column then
-      padding = padding + math.max(column.max_width, self.opts.view.min_column_width) + self.opts.view.spacing
+      padding = padding + math.max(column.max_width, self.opts.view.min_column_width) + spacing_right
     end
 
     -- add padding for delimiters
@@ -326,6 +395,7 @@ function View:_calculate_padding_for_multiline(lnum, row)
         local delimiter_width = vim.fn.strdisplaywidth(delimiter_text)
         padding = padding + delimiter_width
       end
+      padding = padding + spacing_left
     end
   end
 

--- a/tests/cases/enable.lua
+++ b/tests/cases/enable.lua
@@ -65,6 +65,50 @@ return {
     },
   },
   {
+    name = "display_mode  = 'highlight' with left and right spacing",
+    opts = {
+      view = {
+        display_mode = "highlight",
+        spacing = { left = 1, right = 1 },
+        min_column_width = 5,
+      },
+    },
+    lines = {
+      "id,alpha2,alpha3,name",
+      "4,af,afg,Afghanistan",
+      "8,al,alb,Albania",
+      "12,dz,dza,Algeria",
+    },
+    expected = {
+      "id    , alpha2 , alpha3 , name        ",
+      "    4 , af     , afg    , Afghanistan ",
+      "    8 , al     , alb    , Albania     ",
+      "   12 , dz     , dza    , Algeria     ",
+    },
+  },
+  {
+    name = "display_mode  = 'border' with left and right spacing",
+    opts = {
+      view = {
+        display_mode = "border",
+        spacing = { left = 1, right = 1 },
+        min_column_width = 5,
+      },
+    },
+    lines = {
+      "id,alpha2,alpha3,name",
+      "4,af,afg,Afghanistan",
+      "8,al,alb,Albania",
+      "12,dz,dza,Algeria",
+    },
+    expected = {
+      "id    │ alpha2 │ alpha3 │ name        ",
+      "    4 │ af     │ afg    │ Afghanistan ",
+      "    8 │ al     │ alb    │ Albania     ",
+      "   12 │ dz     │ dza    │ Algeria     ",
+    },
+  },
+  {
     name = "multi-byte delimiter and multi-characters delimiter",
     opts = {
       view = {
@@ -211,6 +255,28 @@ return {
       '             111│😀             │"abcde          ',
       "                                 fgh             ",
       '                                 ijk"            ',
+    },
+  },
+  {
+    name = "multiline fields with left and right spacing",
+    opts = {
+      view = {
+        display_mode = "border",
+        spacing = { left = 1, right = 1 },
+        min_column_width = 5,
+      },
+    },
+    lines = {
+      "a,b,c",
+      '1,2,"x',
+      "y",
+      'z"',
+    },
+    expected = {
+      "a     │ b     │ c     ",
+      '    1 │     2 │ "x    ',
+      "                y     ",
+      '                z"    ',
     },
   },
 }


### PR DESCRIPTION
## Summary

This adds support for configuring virtual spacing on both sides of column delimiters.

Users can now write:

```lua
require("csvview").setup({
  view = {
    spacing = {
      left = 1,
      right = 1,
    },
  },
})
```

This makes crowded column-border layouts easier to read.

<table>
  <tr>
    <th><code>view.spacing = 2</code><br/>(Default and existing behavior)</th>
    <th><code>view.spacing = { left = 1, right = 1 }</code><br/>(New spacing mode)</th>
  </tr>
  <tr>
    <td>
      <img width="1392" height="644" alt="image" src="https://github.com/user-attachments/assets/fafd54e4-9d03-41bb-b7df-684f8c38d6f5" />
    </td>
    <td>
      <img width="1379" height="654" alt="image" src="https://github.com/user-attachments/assets/017068e6-cede-48bb-b3cf-90dacbaf1894" />
    </td>
  </tr>
</table>




## Changes

- Extend `view.spacing` to accept either:
    - a number, preserving the existing behavior
    - a table, `{ left = ..., right = ... }`, for delimiter-aware spacing
- Split field rendering padding into:
    - alignment padding, used to keep numeric/text columns aligned
    - delimiter spacing, used to add visual room around column borders
- Add coverage for:
    - highlight display mode
    - border display mode
    - multiline fields
- Update README and GUIDE with the new table-style spacing option

## Notes

This does not add a new column-alignment configuration option yet. It preserves the current behavior where numeric fields are right-aligned and other fields are left-aligned, while making the spacing around delimiters configurable.

#94 
