### PR TITLE
feat(view): add sticky columns

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -241,16 +241,16 @@ in a spreadsheet. The remaining columns slide underneath them.
 Pin or unpin without editing the configuration:
 
 ```vim
-:CsvViewEnable sticky_columns=2  " When enabling the view
-:CsvViewUpdate sticky_columns=2  " On an already attached buffer
-:CsvViewUpdate sticky_columns=0  " Unpin
+:CsvViewEnable sticky_columns=2  " Pin two columns
+:CsvViewEnable sticky_columns=0  " Unpin
 ```
 
-`:CsvViewUpdate` changes any option on an enabled buffer, not just this one:
+`:CsvViewEnable` applies its options to a buffer that is already enabled, so any
+option can be changed without disabling the view first:
 
 ```vim
-:CsvViewUpdate display_mode=border
-:CsvViewUpdate delimiter=; header_lnum=1
+:CsvViewEnable display_mode=border
+:CsvViewEnable delimiter=; header_lnum=1
 ```
 
 When a sticky header is displayed, the header cells of the pinned columns stay in

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -242,12 +242,11 @@ Pin or unpin without editing the configuration:
 
 ```vim
 :CsvViewEnable sticky_columns=2  " When enabling the view
-:CsvViewStickyColumns 2          " On an already attached buffer
-:CsvViewStickyColumns 0          " Unpin
+:CsvViewUpdate sticky_columns=2  " On an already attached buffer
+:CsvViewUpdate sticky_columns=0  " Unpin
 ```
 
-`:CsvViewStickyColumns` is shorthand for `:CsvViewUpdate sticky_columns=2`, which
-changes any option on an enabled buffer:
+`:CsvViewUpdate` changes any option on an enabled buffer, not just this one:
 
 ```vim
 :CsvViewUpdate display_mode=border

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -222,6 +222,35 @@ The plugin automatically detects header rows by analyzing file content:
 }
 ```
 
+## Sticky Columns
+
+Keep the leftmost columns in place while scrolling horizontally, like frozen panes
+in a spreadsheet. The remaining columns slide underneath them.
+
+```lua
+{
+  view = {
+    sticky_columns = {
+      enabled = true,  -- Off by default
+      count = 1,       -- Number of columns to pin, counted from the left
+    },
+  },
+}
+```
+
+Pin or unpin without editing the configuration:
+
+```vim
+:CsvViewEnable sticky_columns=2  " When enabling the view
+:CsvViewStickyColumns 2          " On an already attached buffer
+:CsvViewStickyColumns 0          " Unpin
+```
+
+When a sticky header is displayed, the header cells of the pinned columns stay in
+place with them. While columns are pinned, 'sidescrolloff' is raised for that
+window so the cursor is never hidden behind them; the previous value is restored
+when they are unpinned.
+
 ## Navigation & Text Objects
 
 ### Excel-like Navigation

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -246,6 +246,14 @@ Pin or unpin without editing the configuration:
 :CsvViewStickyColumns 0          " Unpin
 ```
 
+`:CsvViewStickyColumns` is shorthand for `:CsvViewUpdate sticky_columns=2`, which
+changes any option on an enabled buffer:
+
+```vim
+:CsvViewUpdate display_mode=border
+:CsvViewUpdate delimiter=; header_lnum=1
+```
+
 When a sticky header is displayed, the header cells of the pinned columns stay in
 place with them. While columns are pinned, 'sidescrolloff' is raised for that
 window so the cursor is never hidden behind them; the previous value is restored

--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ end)
       --- :CsvViewStickyColumns 2
       --- @type integer
       count = 1,
+
+      --- The separator character drawn at the right edge of the pinned columns,
+      --- where the scrolling columns pass underneath.
+      --- Off by default: with `display_mode = "border"` the pinned columns already
+      --- end in a delimiter there, and a separator would double it.
+      --- set `false` to disable the separator
+      --- @type string|false
+      separator = false,
     },
   },
 
@@ -326,6 +334,7 @@ The plugin uses the following highlight groups for customizing colors and appear
 | `CsvViewDelimiter`               | links to `Comment`         | Delimiter highlighting           |
 | `CsvViewComment`                 | links to `Comment`         | Comment line highlighting        |
 | `CsvViewStickyHeaderSeparator`   | links to `CsvViewDelimiter`| Sticky header separator          |
+| `CsvViewStickyColumnsSeparator`  | links to `CsvViewDelimiter`| Sticky columns separator         |
 | `CsvViewHeaderLine`              | -                          | Header line highlighting         |
 | `CsvViewCol0` to `CsvViewCol8`   | links to `csvCol0`-`csvCol8`| Column-based highlighting       |
 | `CsvViewInfoTitle`               | links to `Title`           | Info window title                |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ end)
       --- You can also specify it on the command line.
       --- e.g:
       --- :CsvViewEnable sticky_columns=2
-      --- :CsvViewStickyColumns 2
+      --- :CsvViewUpdate sticky_columns=2
       --- @type integer
       count = 1,
 
@@ -302,7 +302,6 @@ end)
 | `:CsvViewToggle [options]` | Toggle CSV view with the specified options      |
 | `:CsvViewInfo`             | Display buffer statistics (delimiter, header, dimensions) |
 | `:CsvViewUpdate [options]` | Change options of an enabled buffer               |
-| `:CsvViewStickyColumns [N]` | Pin the leftmost N columns of the attached buffer (`0` unpins) |
 
 #### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ end)
       --- You can also specify it on the command line.
       --- e.g:
       --- :CsvViewEnable sticky_columns=2
-      --- :CsvViewUpdate sticky_columns=2
       --- @type integer
       count = 1,
 
@@ -297,11 +296,10 @@ end)
 
 | Command                    | Description                                      |
 |----------------------------|--------------------------------------------------|
-| `:CsvViewEnable [options]` | Enable CSV view with the specified options      |
+| `:CsvViewEnable [options]` | Enable CSV view with the specified options, or apply them to an already enabled buffer |
 | `:CsvViewDisable`          | Disable CSV view                                 |
 | `:CsvViewToggle [options]` | Toggle CSV view with the specified options      |
 | `:CsvViewInfo`             | Display buffer statistics (delimiter, header, dimensions) |
-| `:CsvViewUpdate [options]` | Change options of an enabled buffer               |
 
 #### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ end)
 | `:CsvViewDisable`          | Disable CSV view                                 |
 | `:CsvViewToggle [options]` | Toggle CSV view with the specified options      |
 | `:CsvViewInfo`             | Display buffer statistics (delimiter, header, dimensions) |
+| `:CsvViewUpdate [options]` | Change options of an enabled buffer               |
 | `:CsvViewStickyColumns [N]` | Pin the leftmost N columns of the attached buffer (`0` unpins) |
 
 #### Quick Start

--- a/README.md
+++ b/README.md
@@ -228,6 +228,23 @@ end)
       --- @type string|false
       separator = "─",
     },
+
+    --- The sticky columns feature settings
+    --- Keeps the leftmost columns in place while scrolling horizontally,
+    --- like frozen panes in a spreadsheet.
+    sticky_columns = {
+      --- Whether to enable the sticky columns feature
+      --- @type boolean
+      enabled = false,
+
+      --- Number of columns to pin, counted from the left.
+      --- You can also specify it on the command line.
+      --- e.g:
+      --- :CsvViewEnable sticky_columns=2
+      --- :CsvViewStickyColumns 2
+      --- @type integer
+      count = 1,
+    },
   },
 
   --- Keymaps for csvview.
@@ -276,6 +293,7 @@ end)
 | `:CsvViewDisable`          | Disable CSV view                                 |
 | `:CsvViewToggle [options]` | Toggle CSV view with the specified options      |
 | `:CsvViewInfo`             | Display buffer statistics (delimiter, header, dimensions) |
+| `:CsvViewStickyColumns [N]` | Pin the leftmost N columns of the attached buffer (`0` unpins) |
 
 #### Quick Start
 

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -15,6 +15,7 @@ local M = {}
 ---@field display_mode? CsvView.Options.View.DisplayMode
 ---@field header_lnum? integer|false|true
 ---@field sticky_header? CsvView.Options.View.StickyHeader
+---@field sticky_columns? CsvView.Options.View.StickyColumns
 ---@alias CsvView.Options.View.DisplayMode "highlight" | "border"
 
 ---@class CsvView.Options.View.Spacing
@@ -24,6 +25,10 @@ local M = {}
 ---@class CsvView.Options.View.StickyHeader
 ---@field enabled? boolean
 ---@field separator? string|false
+
+---@class CsvView.Options.View.StickyColumns
+---@field enabled? boolean
+---@field count? integer
 
 ---@class CsvView.Options.Keymaps
 ---@field textobject_field_inner? CsvView.Keymap
@@ -176,6 +181,23 @@ M.defaults = {
       --- set `false` to disable the separator
       --- @type string|false
       separator = "─",
+    },
+
+    --- The sticky columns feature settings
+    --- Keeps the leftmost columns in place while scrolling horizontally,
+    --- like frozen panes in a spreadsheet.
+    sticky_columns = {
+      --- Whether to enable the sticky columns feature
+      --- @type boolean
+      enabled = false,
+
+      --- Number of columns to pin, counted from the left.
+      --- You can also specify it on the command line.
+      --- e.g:
+      --- :CsvViewEnable sticky_columns=2
+      --- :CsvViewStickyColumns 2
+      --- @type integer
+      count = 1,
     },
   },
 

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -196,7 +196,7 @@ M.defaults = {
       --- You can also specify it on the command line.
       --- e.g:
       --- :CsvViewEnable sticky_columns=2
-      --- :CsvViewStickyColumns 2
+      --- :CsvViewUpdate sticky_columns=2
       --- @type integer
       count = 1,
 

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -196,7 +196,6 @@ M.defaults = {
       --- You can also specify it on the command line.
       --- e.g:
       --- :CsvViewEnable sticky_columns=2
-      --- :CsvViewUpdate sticky_columns=2
       --- @type integer
       count = 1,
 

--- a/lua/csvview/config.lua
+++ b/lua/csvview/config.lua
@@ -29,6 +29,7 @@ local M = {}
 ---@class CsvView.Options.View.StickyColumns
 ---@field enabled? boolean
 ---@field count? integer
+---@field separator? string|false
 
 ---@class CsvView.Options.Keymaps
 ---@field textobject_field_inner? CsvView.Keymap
@@ -198,6 +199,14 @@ M.defaults = {
       --- :CsvViewStickyColumns 2
       --- @type integer
       count = 1,
+
+      --- The separator character drawn at the right edge of the pinned columns,
+      --- where the scrolling columns pass underneath.
+      --- Off by default: with `display_mode = "border"` the pinned columns already
+      --- end in a delimiter there, and a separator would double it.
+      --- set `false` to disable the separator
+      --- @type string|false
+      separator = false,
     },
   },
 
@@ -313,6 +322,7 @@ local HL = {
   Comment = "CsvViewComment",
   HeaderLine = "CsvViewHeaderLine",
   StickyHeaderSeparator = "CsvViewStickyHeaderSeparator",
+  StickyColumnsSeparator = "CsvViewStickyColumnsSeparator",
   -- use built-in csv syntax highlight group.
   Col0 = "CsvViewCol0",
   Col1 = "CsvViewCol1",
@@ -345,6 +355,7 @@ M._highlight_links = {
   [HL.Comment] = "Comment",
   [HL.HeaderLine] = false,
   [HL.StickyHeaderSeparator] = "Delimiter",
+  [HL.StickyColumnsSeparator] = "Delimiter",
   [HL.Col0] = "csvCol0",
   [HL.Col1] = "csvCol1",
   [HL.Col2] = "csvCol2",

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local CsvView = require("csvview.view").View
+local sticky_columns = require("csvview.sticky_columns")
 local sticky_header = require("csvview.sticky_header")
 local views = require("csvview.view")
 
@@ -141,6 +142,7 @@ function M.enable(bufnr, opts)
     metrics:clear()
     keymap.unregister(opts)
     sticky_header.redraw()
+    sticky_columns.redraw()
     vim.bo[bufnr].syntax = orig_syntax
     vim.b[bufnr].csvview_info = nil
     vim.api.nvim_exec_autocmds("User", { pattern = "CsvViewDetach", data = bufnr })
@@ -160,6 +162,7 @@ function M.enable(bufnr, opts)
     keymap.register(opts)
     views.attach(bufnr, view)
     sticky_header.redraw()
+    sticky_columns.redraw()
     vim.cmd([[redraw!]])
     vim.api.nvim_exec_autocmds("User", { pattern = "CsvViewAttach", data = bufnr })
   end)
@@ -191,6 +194,25 @@ function M.toggle(bufnr, opts)
   else
     M.enable(bufnr, opts)
   end
+end
+
+--- Set the number of pinned columns for a buffer.
+---
+--- Enables sticky columns for `count >= 1` and disables them for 0. The view is
+--- already attached at this point, so this only retunes the overlay.
+---@param bufnr integer?
+---@param count integer
+function M.set_sticky_columns(bufnr, count)
+  bufnr = util.resolve_bufnr(bufnr)
+  local view = views.get(bufnr)
+  if not view then
+    vim.notify("csvview: not enabled for this buffer.", vim.log.levels.WARN)
+    return
+  end
+
+  view.opts.view.sticky_columns.enabled = count >= 1
+  view.opts.view.sticky_columns.count = math.max(count, 1)
+  sticky_columns.redraw()
 end
 
 --- Register autocmds
@@ -240,20 +262,27 @@ function M.setup(opts)
   -- Register autocmds
   local group = vim.api.nvim_create_augroup("csvview", {})
   register_autocmds({
-    { -- `CursorMoved` is necessary to hide the sticky header when cursor overlaps the header.
+    { -- `CursorMoved` is necessary to hide the overlays when the cursor is underneath them.
       event = { "WinEnter", "WinScrolled", "WinResized", "VimResized", "CursorMoved" },
-      callback = sticky_header.redraw,
+      callback = function()
+        sticky_header.redraw()
+        sticky_columns.redraw()
+      end,
     },
     {
       event = "OptionSet",
       pattern = { "number", "relativenumber", "numberwidth", "signcolumn", "foldcolumn" },
-      callback = sticky_header.redraw,
+      callback = function()
+        sticky_header.redraw()
+        sticky_columns.redraw()
+      end,
     },
     {
       event = "WinClosed",
       callback = function(args)
         local winid = assert(tonumber(args.match))
         sticky_header.close_header_win_for(winid)
+        sticky_columns.close_columns_win_for(winid)
       end,
     },
     { -- Detach view when the buffer is deleted

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -196,22 +196,37 @@ function M.toggle(bufnr, opts)
   end
 end
 
---- Set the number of pinned columns for a buffer.
+--- Change options of an already enabled buffer.
 ---
---- Enables sticky columns for `count >= 1` and disables them for 0. The view is
---- already attached at this point, so this only retunes the overlay.
+--- `opts` is merged over the options the buffer was enabled with. View options are
+--- re-applied to the attached view and the buffer is re-rendered. Parser options
+--- decide how the buffer is split into fields, so changing one re-parses the buffer,
+--- which is a disable and enable round trip.
 ---@param bufnr integer?
----@param count integer
-function M.set_sticky_columns(bufnr, count)
+---@param opts CsvView.Options
+function M.update(bufnr, opts)
   bufnr = util.resolve_bufnr(bufnr)
   local view = views.get(bufnr)
   if not view then
-    vim.notify("csvview: not enabled for this buffer.", vim.log.levels.WARN)
+    vim.notify("csvview: not enabled for this buffer.")
     return
   end
 
-  view.opts.view.sticky_columns.enabled = count >= 1
-  view.opts.view.sticky_columns.count = math.max(count, 1)
+  local merged = vim.tbl_deep_extend("force", view.opts, opts) --[[@as CsvView.InternalOptions]]
+  if not vim.deep_equal(merged.parser, view.opts.parser) then
+    M.disable(bufnr)
+    M.enable(bufnr, merged)
+    return
+  end
+
+  view.opts = merged
+  view:clear()
+  for _, winid in ipairs(util.buf_tabpage_win_find(0, bufnr)) do
+    view:setup_window(winid) -- `display_mode` decides the conceal options
+  end
+
+  vim.b[bufnr].csvview_refresh_requested = true
+  sticky_header.redraw()
   sticky_columns.redraw()
 end
 

--- a/lua/csvview/init.lua
+++ b/lua/csvview/init.lua
@@ -21,7 +21,39 @@ function M.is_enabled(bufnr)
   return views.get(bufnr) ~= nil
 end
 
+--- Apply options to an already attached buffer.
+---
+--- View options only need the view re-rendered. Parser options decide how the
+--- buffer is split into fields, so changing one re-parses it, which is a disable
+--- and enable round trip.
+---@param bufnr integer
+---@param view CsvView.View
+---@param opts CsvView.Options
+local function reapply(bufnr, view, opts)
+  local merged = vim.tbl_deep_extend("force", view.opts, opts) --[[@as CsvView.InternalOptions]]
+  if not vim.deep_equal(merged.parser, view.opts.parser) then
+    M.disable(bufnr)
+    M.enable(bufnr, merged)
+    return
+  end
+
+  view.opts = merged
+  view:clear()
+  for _, winid in ipairs(util.buf_tabpage_win_find(0, bufnr)) do
+    view:setup_window(winid) -- `display_mode` decides the conceal options
+  end
+
+  vim.b[bufnr].csvview_refresh_requested = true
+  sticky_header.redraw()
+  sticky_columns.redraw()
+end
+
 --- enable csv table view
+---
+--- On a buffer that is already enabled, `opts` is applied to it instead: the
+--- options are merged over the ones the buffer currently uses, view options are
+--- re-applied to the attached view, and parser options, which decide how the
+--- buffer is split into fields, re-parse it.
 ---@param bufnr integer?
 ---@param opts CsvView.Options?
 function M.enable(bufnr, opts)
@@ -30,12 +62,13 @@ function M.enable(bufnr, opts)
   end
 
   bufnr = util.resolve_bufnr(bufnr)
-  opts = config.get(opts) ---@diagnostic disable-line: cast-local-type
 
-  if M.is_enabled(bufnr) then
-    vim.notify("csvview: already enabled for this buffer.")
-    return
+  local attached = views.get(bufnr)
+  if attached then
+    return reapply(bufnr, attached, opts or {})
   end
+
+  opts = config.get(opts) ---@diagnostic disable-line: cast-local-type
 
   local quote_char, quote_char_detected, quote_char_scores = util.resolve_quote_char(bufnr, opts)
   local delimiter, delimiter_detected, delimiter_scores = util.resolve_delimiter(bufnr, opts, quote_char)
@@ -194,40 +227,6 @@ function M.toggle(bufnr, opts)
   else
     M.enable(bufnr, opts)
   end
-end
-
---- Change options of an already enabled buffer.
----
---- `opts` is merged over the options the buffer was enabled with. View options are
---- re-applied to the attached view and the buffer is re-rendered. Parser options
---- decide how the buffer is split into fields, so changing one re-parses the buffer,
---- which is a disable and enable round trip.
----@param bufnr integer?
----@param opts CsvView.Options
-function M.update(bufnr, opts)
-  bufnr = util.resolve_bufnr(bufnr)
-  local view = views.get(bufnr)
-  if not view then
-    vim.notify("csvview: not enabled for this buffer.")
-    return
-  end
-
-  local merged = vim.tbl_deep_extend("force", view.opts, opts) --[[@as CsvView.InternalOptions]]
-  if not vim.deep_equal(merged.parser, view.opts.parser) then
-    M.disable(bufnr)
-    M.enable(bufnr, merged)
-    return
-  end
-
-  view.opts = merged
-  view:clear()
-  for _, winid in ipairs(util.buf_tabpage_win_find(0, bufnr)) do
-    view:setup_window(winid) -- `display_mode` decides the conceal options
-  end
-
-  vim.b[bufnr].csvview_refresh_requested = true
-  sticky_header.redraw()
-  sticky_columns.redraw()
 end
 
 --- Register autocmds

--- a/lua/csvview/sticky_columns.lua
+++ b/lua/csvview/sticky_columns.lua
@@ -3,6 +3,7 @@ local win_overlay = require("csvview.win_overlay")
 local M = {}
 
 M._sticky_columns_wins = {} --- @type table<integer,integer> winid -> sticky-columns winid
+M._saved_sidescrolloff = {} --- @type table<integer,integer> winid -> 'sidescrolloff' before pinning
 
 --- Sync the vertical scroll of the sticky columns window with the main window.
 ---
@@ -60,19 +61,13 @@ local function show_sticky_columns(winid, view, width)
   vim.api.nvim_set_option_value("wrap", false, { win = columns_winid, scope = "local" })
 end
 
---- Width of the pinned region, or nil if sticky columns should not be shown.
+--- Width of the pinned region, or nil if this window has nothing to pin.
 ---@param winid integer
 ---@param view CsvView.View
 ---@return integer?
-local function sticky_columns_width(winid, view)
+local function pinned_width(winid, view)
   local opts = view.opts.view.sticky_columns
   if not opts.enabled or opts.count < 1 then
-    return nil
-  end
-
-  -- Nothing is scrolled out of view yet, the real columns are already in place.
-  local leftcol = vim.api.nvim_win_call(winid, vim.fn.winsaveview).leftcol
-  if leftcol <= 0 then
     return nil
   end
 
@@ -82,22 +77,61 @@ local function sticky_columns_width(winid, view)
     return nil
   end
 
-  -- The overlay is not focusable, so a cursor inside the pinned region would be
-  -- hidden underneath it. Give the cursor back to the user in that case.
-  local cursor_screen_col = vim.api.nvim_win_call(winid, vim.fn.wincol)
+  -- Never cover the whole window.
   local gutter = vim.fn.getwininfo(winid)[1].textoff or 0
-  if cursor_screen_col - gutter <= width then
-    return nil
+  return math.min(width, vim.api.nvim_win_get_width(winid) - gutter - 1)
+end
+
+--- Whether the overlay should currently be drawn.
+---
+--- Only when something is actually scrolled out of view: at `leftcol == 0` the real
+--- columns are already in place. The cursor cannot be caught behind the overlay,
+--- since 'sidescrolloff' keeps it to the right of the pinned region.
+---@param winid integer
+---@return boolean
+local function should_show(winid)
+  return vim.api.nvim_win_call(winid, vim.fn.winsaveview).leftcol > 0
+end
+
+--- Keep the cursor clear of the pinned region.
+---
+--- The overlay is not focusable, so a cursor underneath it would be invisible.
+--- 'sidescrolloff' is the native mechanism for this: it keeps the cursor that many
+--- columns away from the window edge, so horizontal scrolling still works normally
+--- and the cursor simply never ends up behind the overlay.
+---@param winid integer
+---@param width integer
+local function set_sidescrolloff(winid, width)
+  local opts = { win = winid, scope = "local" } ---@type vim.api.keyset.option
+  if M._saved_sidescrolloff[winid] == nil then
+    M._saved_sidescrolloff[winid] = vim.api.nvim_get_option_value("sidescrolloff", opts)
   end
 
-  -- Never cover the whole window.
-  local max_width = vim.api.nvim_win_get_width(winid) - gutter - 1
-  return math.min(width, max_width)
+  local wanted = width + 1
+  if vim.api.nvim_get_option_value("sidescrolloff", opts) ~= wanted then
+    vim.api.nvim_set_option_value("sidescrolloff", wanted, opts)
+  end
+end
+
+--- Restore the 'sidescrolloff' the window had before the overlay was shown.
+---@param winid integer
+local function restore_sidescrolloff(winid)
+  local saved = M._saved_sidescrolloff[winid]
+  if saved == nil then
+    return
+  end
+
+  M._saved_sidescrolloff[winid] = nil
+  if vim.api.nvim_win_is_valid(winid) then
+    vim.api.nvim_set_option_value("sidescrolloff", saved, { win = winid, scope = "local" })
+  end
 end
 
 --- Close the sticky columns window of a csvview window
 ---@param winid integer
 function M.close_columns_win_for(winid)
+  restore_sidescrolloff(winid)
+
   local columns_win = M._sticky_columns_wins[winid]
   if not columns_win then
     return
@@ -120,12 +154,25 @@ end
 function M.redraw()
   for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
     local view = win_overlay.get_opened_csvview(winid)
-    local width = view and sticky_columns_width(winid, view)
-    if view and width then
-      show_sticky_columns(winid, view, width)
-      sync_vertical_scroll(winid, M._sticky_columns_wins[winid])
-    else
+    local width = view and pinned_width(winid, view)
+    if not width then
       M.close_columns_win_for(winid)
+    else
+      -- Reserve the room before the overlay is needed, so the cursor is never
+      -- caught behind it on the redraw that first scrolls the window.
+      set_sidescrolloff(winid, width)
+      if should_show(winid) then
+        show_sticky_columns(winid, view, width)
+        sync_vertical_scroll(winid, M._sticky_columns_wins[winid])
+      elseif M._sticky_columns_wins[winid] then
+        local columns_win = M._sticky_columns_wins[winid]
+        M._sticky_columns_wins[winid] = nil
+        vim.schedule(function()
+          if vim.api.nvim_win_is_valid(columns_win) then
+            pcall(vim.api.nvim_win_close, columns_win, true)
+          end
+        end)
+      end
     end
   end
 end

--- a/lua/csvview/sticky_columns.lua
+++ b/lua/csvview/sticky_columns.lua
@@ -3,62 +3,111 @@ local win_overlay = require("csvview.win_overlay")
 local M = {}
 
 M._sticky_columns_wins = {} --- @type table<integer,integer> winid -> sticky-columns winid
+M._corner_wins = {} --- @type table<integer,integer> winid -> pinned-header-corner winid
 M._saved_sidescrolloff = {} --- @type table<integer,integer> winid -> 'sidescrolloff' before pinning
 
---- Sync the vertical scroll of the sticky columns window with the main window.
+--- Width of the gutter (number column, signs, folds) of a window.
+---@param winid integer
+---@return integer
+local function gutter_width(winid)
+  return vim.fn.getwininfo(winid)[1].textoff or 0
+end
+
+--- Open or update an overlay window covering the pinned columns.
 ---
---- The overlay shows the same buffer with `leftcol` held at 0, so the pinned columns
---- stay in place while the main window scrolls horizontally.
+--- The overlay shows the same buffer, so csvview's alignment padding, which lives
+--- in buffer extmarks, renders exactly as it does in the main window. It is placed
+--- after the main window's gutter and draws no gutter of its own, so its whole
+--- width is text and the columns line up.
+---@param wins table<integer,integer> winid -> overlay winid
 ---@param winid integer csvview attached window
----@param columns_winid integer sticky-columns window
-local function sync_vertical_scroll(winid, columns_winid)
-  local win_view = vim.api.nvim_win_call(winid, vim.fn.winsaveview) ---@type vim.fn.winsaveview.ret
-  vim.api.nvim_win_call(columns_winid, function()
+---@param view CsvView.View
+---@param role "columns"|"corner"
+---@param win_opts vim.api.keyset.win_config
+---@return integer overlay_winid
+local function open_overlay(wins, winid, view, role, win_opts)
+  win_opts.win = winid
+  win_opts.relative = "win"
+  win_opts.col = gutter_width(winid)
+  win_opts.focusable = false
+  win_opts.style = "minimal"
+
+  local overlay_winid = wins[winid]
+  if not overlay_winid or not vim.api.nvim_win_is_valid(overlay_winid) then
+    win_opts.noautocmd = true
+    overlay_winid = vim.api.nvim_open_win(view.bufnr, false, win_opts)
+    wins[winid] = overlay_winid
+  else
+    vim.api.nvim_win_set_config(overlay_winid, win_opts)
+    if vim.api.nvim_win_get_buf(overlay_winid) ~= view.bufnr then
+      vim.api.nvim_win_set_buf(overlay_winid, view.bufnr)
+    end
+  end
+
+  -- Mark as sticky columns window ("columns" or "corner")
+  vim.w[overlay_winid].csvview_sticky_columns_win = role
+
+  -- No gutter of its own: the main window already draws one to the left of it.
+  local opts = { win = overlay_winid, scope = "local" } ---@type vim.api.keyset.option
+  vim.api.nvim_set_option_value("statuscolumn", "", opts)
+  vim.api.nvim_set_option_value("signcolumn", "no", opts)
+  vim.api.nvim_set_option_value("foldcolumn", "0", opts)
+  -- use Normal instead of NormalFloat
+  vim.api.nvim_set_option_value("winhighlight", "NormalFloat:Normal", opts)
+
+  -- Same conceal and wrap setup as the csvview window, so `display_mode = "border"`
+  -- renders the delimiter here the same way.
+  view:setup_window(overlay_winid)
+
+  return overlay_winid
+end
+
+--- Scroll an overlay to the given line, with the pinned columns in view.
+---@param overlay_winid integer
+---@param lnum integer
+local function scroll_overlay_to(overlay_winid, lnum)
+  vim.api.nvim_win_call(overlay_winid, function()
     local current = vim.fn.winsaveview()
-    if current.topline ~= win_view.topline or current.leftcol ~= 0 then
-      vim.fn.winrestview({ topline = win_view.topline, lnum = win_view.topline, leftcol = 0 })
+    if current.topline ~= lnum or current.leftcol ~= 0 then
+      vim.fn.winrestview({ topline = lnum, lnum = lnum, leftcol = 0 })
     end
   end)
 end
 
---- Display sticky columns.
+--- Display the pinned columns.
 ---@param winid integer
 ---@param view CsvView.View
 ---@param width integer
 local function show_sticky_columns(winid, view, width)
-  -- Same approach as the sticky header, rotated 90 degrees: a floating window showing
-  -- the same buffer. Since csvview's alignment padding lives in buffer extmarks, the
-  -- overlay renders the columns exactly as the main window does.
-  local win_opts = { ---@type vim.api.keyset.win_config
-    win = winid,
-    relative = "win",
+  local overlay = open_overlay(M._sticky_columns_wins, winid, view, "columns", {
     width = width,
     height = vim.api.nvim_win_get_height(winid),
     row = 0,
-    col = 0,
-    focusable = false,
-    style = "minimal",
-    -- Keep the sticky header, which is created at the same position, on top.
+    -- Below the sticky header, which covers the same top row.
     zindex = 45,
-  }
+  })
 
-  local columns_winid = M._sticky_columns_wins[winid]
-  if not columns_winid or not vim.api.nvim_win_is_valid(columns_winid) then
-    win_opts.noautocmd = true
-    columns_winid = vim.api.nvim_open_win(view.bufnr, false, win_opts)
-    M._sticky_columns_wins[winid] = columns_winid
-  else
-    vim.api.nvim_win_set_config(columns_winid, win_opts)
-    if vim.api.nvim_win_get_buf(columns_winid) ~= view.bufnr then
-      vim.api.nvim_win_set_buf(columns_winid, view.bufnr)
-    end
-  end
+  scroll_overlay_to(overlay, vim.api.nvim_win_call(winid, vim.fn.winsaveview).topline)
+end
 
-  -- Mark as sticky columns window
-  vim.w[columns_winid].csvview_sticky_columns_win = true
+--- Display the pinned columns of the header line, on top of the sticky header.
+---
+--- The sticky header scrolls horizontally with the window, so without this the
+--- header cells of the pinned columns would slide away while their data cells
+--- stay put.
+---@param winid integer
+---@param view CsvView.View
+---@param width integer
+local function show_corner(winid, view, width)
+  local overlay = open_overlay(M._corner_wins, winid, view, "corner", {
+    width = width,
+    height = 1,
+    row = 0,
+    -- Above the sticky header.
+    zindex = 55,
+  })
 
-  win_overlay.setup_overlay_win_options(columns_winid, winid)
-  vim.api.nvim_set_option_value("wrap", false, { win = columns_winid, scope = "local" })
+  scroll_overlay_to(overlay, view.header_lnum)
 end
 
 --- Width of the pinned region, or nil if this window has nothing to pin.
@@ -77,9 +126,8 @@ local function pinned_width(winid, view)
     return nil
   end
 
-  -- Never cover the whole window.
-  local gutter = vim.fn.getwininfo(winid)[1].textoff or 0
-  return math.min(width, vim.api.nvim_win_get_width(winid) - gutter - 1)
+  -- Never cover the whole text area.
+  return math.min(width, vim.api.nvim_win_get_width(winid) - gutter_width(winid) - 1)
 end
 
 --- Whether the overlay should currently be drawn.
@@ -127,27 +175,34 @@ local function restore_sidescrolloff(winid)
   end
 end
 
---- Close the sticky columns window of a csvview window
+--- Close one overlay window
+---@param wins table<integer,integer> winid -> overlay winid
 ---@param winid integer
-function M.close_columns_win_for(winid)
-  restore_sidescrolloff(winid)
-
-  local columns_win = M._sticky_columns_wins[winid]
-  if not columns_win then
+local function close_overlay(wins, winid)
+  local overlay = wins[winid]
+  if not overlay then
     return
   end
 
-  M._sticky_columns_wins[winid] = nil
-  if not vim.api.nvim_win_is_valid(columns_win) then
+  wins[winid] = nil
+  if not vim.api.nvim_win_is_valid(overlay) then
     return
   end
 
   -- Close (use vim.schedule to avoid issues when called during BufUnload)
   vim.schedule(function()
-    if vim.api.nvim_win_is_valid(columns_win) then
-      pcall(vim.api.nvim_win_close, columns_win, true)
+    if vim.api.nvim_win_is_valid(overlay) then
+      pcall(vim.api.nvim_win_close, overlay, true)
     end
   end)
+end
+
+--- Close the sticky columns windows of a csvview window
+---@param winid integer
+function M.close_columns_win_for(winid)
+  restore_sidescrolloff(winid)
+  close_overlay(M._sticky_columns_wins, winid)
+  close_overlay(M._corner_wins, winid)
 end
 
 --- Redraw all sticky columns
@@ -157,21 +212,22 @@ function M.redraw()
     local width = view and pinned_width(winid, view)
     if not width then
       M.close_columns_win_for(winid)
+    elseif not should_show(winid) then
+      -- Keep the reservation, drop the overlays.
+      set_sidescrolloff(winid, width)
+      close_overlay(M._sticky_columns_wins, winid)
+      close_overlay(M._corner_wins, winid)
     else
       -- Reserve the room before the overlay is needed, so the cursor is never
       -- caught behind it on the redraw that first scrolls the window.
       set_sidescrolloff(winid, width)
-      if should_show(winid) then
-        show_sticky_columns(winid, view, width)
-        sync_vertical_scroll(winid, M._sticky_columns_wins[winid])
-      elseif M._sticky_columns_wins[winid] then
-        local columns_win = M._sticky_columns_wins[winid]
-        M._sticky_columns_wins[winid] = nil
-        vim.schedule(function()
-          if vim.api.nvim_win_is_valid(columns_win) then
-            pcall(vim.api.nvim_win_close, columns_win, true)
-          end
-        end)
+      show_sticky_columns(winid, view, width)
+
+      -- The corner is only needed where a sticky header is actually drawn.
+      if view.header_lnum and require("csvview.sticky_header")._sticky_header_wins[winid] then
+        show_corner(winid, view, width)
+      else
+        close_overlay(M._corner_wins, winid)
       end
     end
   end

--- a/lua/csvview/sticky_columns.lua
+++ b/lua/csvview/sticky_columns.lua
@@ -140,8 +140,11 @@ local function pinned_width(winid, view)
     return nil
   end
 
-  -- Never cover the whole text area.
-  return math.min(width, vim.api.nvim_win_get_width(winid) - gutter_width(winid) - 1)
+  -- Never take more than half the text area: the region is reserved with
+  -- 'sidescrolloff', which applies to both edges, so a wider one would leave the
+  -- window unable to scroll horizontally at all.
+  local text_width = vim.api.nvim_win_get_width(winid) - gutter_width(winid)
+  return math.min(width, math.floor(text_width / 2))
 end
 
 --- Whether the overlay should currently be drawn.

--- a/lua/csvview/sticky_columns.lua
+++ b/lua/csvview/sticky_columns.lua
@@ -13,6 +13,19 @@ local function gutter_width(winid)
   return vim.fn.getwininfo(winid)[1].textoff or 0
 end
 
+--- Get the separator drawn at the right edge of the pinned columns.
+---@param opts CsvView.InternalOptions
+---@return (string| { [1]:string, [2]:string })[]?
+local function get_separator_border(opts)
+  local separator = opts.view.sticky_columns.separator
+  if not separator then
+    return nil
+  end
+
+  local edge = { separator, "CsvViewStickyColumnsSeparator" }
+  return { "", "", edge, edge, edge, "", "", "" }
+end
+
 --- Open or update an overlay window covering the pinned columns.
 ---
 --- The overlay shows the same buffer, so csvview's alignment padding, which lives
@@ -31,6 +44,7 @@ local function open_overlay(wins, winid, view, role, win_opts)
   win_opts.col = gutter_width(winid)
   win_opts.focusable = false
   win_opts.style = "minimal"
+  win_opts.border = get_separator_border(view.opts)
 
   local overlay_winid = wins[winid]
   if not overlay_winid or not vim.api.nvim_win_is_valid(overlay_winid) then

--- a/lua/csvview/sticky_columns.lua
+++ b/lua/csvview/sticky_columns.lua
@@ -1,0 +1,133 @@
+local win_overlay = require("csvview.win_overlay")
+
+local M = {}
+
+M._sticky_columns_wins = {} --- @type table<integer,integer> winid -> sticky-columns winid
+
+--- Sync the vertical scroll of the sticky columns window with the main window.
+---
+--- The overlay shows the same buffer with `leftcol` held at 0, so the pinned columns
+--- stay in place while the main window scrolls horizontally.
+---@param winid integer csvview attached window
+---@param columns_winid integer sticky-columns window
+local function sync_vertical_scroll(winid, columns_winid)
+  local win_view = vim.api.nvim_win_call(winid, vim.fn.winsaveview) ---@type vim.fn.winsaveview.ret
+  vim.api.nvim_win_call(columns_winid, function()
+    local current = vim.fn.winsaveview()
+    if current.topline ~= win_view.topline or current.leftcol ~= 0 then
+      vim.fn.winrestview({ topline = win_view.topline, lnum = win_view.topline, leftcol = 0 })
+    end
+  end)
+end
+
+--- Display sticky columns.
+---@param winid integer
+---@param view CsvView.View
+---@param width integer
+local function show_sticky_columns(winid, view, width)
+  -- Same approach as the sticky header, rotated 90 degrees: a floating window showing
+  -- the same buffer. Since csvview's alignment padding lives in buffer extmarks, the
+  -- overlay renders the columns exactly as the main window does.
+  local win_opts = { ---@type vim.api.keyset.win_config
+    win = winid,
+    relative = "win",
+    width = width,
+    height = vim.api.nvim_win_get_height(winid),
+    row = 0,
+    col = 0,
+    focusable = false,
+    style = "minimal",
+    -- Keep the sticky header, which is created at the same position, on top.
+    zindex = 45,
+  }
+
+  local columns_winid = M._sticky_columns_wins[winid]
+  if not columns_winid or not vim.api.nvim_win_is_valid(columns_winid) then
+    win_opts.noautocmd = true
+    columns_winid = vim.api.nvim_open_win(view.bufnr, false, win_opts)
+    M._sticky_columns_wins[winid] = columns_winid
+  else
+    vim.api.nvim_win_set_config(columns_winid, win_opts)
+    if vim.api.nvim_win_get_buf(columns_winid) ~= view.bufnr then
+      vim.api.nvim_win_set_buf(columns_winid, view.bufnr)
+    end
+  end
+
+  -- Mark as sticky columns window
+  vim.w[columns_winid].csvview_sticky_columns_win = true
+
+  win_overlay.setup_overlay_win_options(columns_winid, winid)
+  vim.api.nvim_set_option_value("wrap", false, { win = columns_winid, scope = "local" })
+end
+
+--- Width of the pinned region, or nil if sticky columns should not be shown.
+---@param winid integer
+---@param view CsvView.View
+---@return integer?
+local function sticky_columns_width(winid, view)
+  local opts = view.opts.view.sticky_columns
+  if not opts.enabled or opts.count < 1 then
+    return nil
+  end
+
+  -- Nothing is scrolled out of view yet, the real columns are already in place.
+  local leftcol = vim.api.nvim_win_call(winid, vim.fn.winsaveview).leftcol
+  if leftcol <= 0 then
+    return nil
+  end
+
+  -- Metrics not computed yet, or the buffer has fewer columns than requested.
+  local width = view:pinned_width(opts.count)
+  if not width or width <= 0 then
+    return nil
+  end
+
+  -- The overlay is not focusable, so a cursor inside the pinned region would be
+  -- hidden underneath it. Give the cursor back to the user in that case.
+  local cursor_screen_col = vim.api.nvim_win_call(winid, vim.fn.wincol)
+  local gutter = vim.fn.getwininfo(winid)[1].textoff or 0
+  if cursor_screen_col - gutter <= width then
+    return nil
+  end
+
+  -- Never cover the whole window.
+  local max_width = vim.api.nvim_win_get_width(winid) - gutter - 1
+  return math.min(width, max_width)
+end
+
+--- Close the sticky columns window of a csvview window
+---@param winid integer
+function M.close_columns_win_for(winid)
+  local columns_win = M._sticky_columns_wins[winid]
+  if not columns_win then
+    return
+  end
+
+  M._sticky_columns_wins[winid] = nil
+  if not vim.api.nvim_win_is_valid(columns_win) then
+    return
+  end
+
+  -- Close (use vim.schedule to avoid issues when called during BufUnload)
+  vim.schedule(function()
+    if vim.api.nvim_win_is_valid(columns_win) then
+      pcall(vim.api.nvim_win_close, columns_win, true)
+    end
+  end)
+end
+
+--- Redraw all sticky columns
+function M.redraw()
+  for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    local view = win_overlay.get_opened_csvview(winid)
+    local width = view and sticky_columns_width(winid, view)
+    if view and width then
+      show_sticky_columns(winid, view, width)
+      sync_vertical_scroll(winid, M._sticky_columns_wins[winid])
+    else
+      M.close_columns_win_for(winid)
+    end
+  end
+end
+
+return M

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -126,6 +126,18 @@ function M.close_header_win_for(winid)
   end)
 end
 
+--- statuscolumn function for the sticky header window.
+---
+--- Kept because it is referenced by name from the 'statuscolumn' expression, so a
+--- user configuration may hold a copy of that string.
+---@deprecated use `require("csvview.win_overlay").statuscolumn`
+---@param winid integer csvview attached window
+---@return string statuscolumn
+function M.statuscolumn(winid)
+  vim.deprecate("csvview.sticky_header.statuscolumn", "csvview.win_overlay.statuscolumn", "2.0.0", "csvview.nvim")
+  return win_overlay.statuscolumn(winid)
+end
+
 --- Redraw all sticky headers
 function M.redraw()
   local wins = vim.api.nvim_tabpage_list_wins(0)

--- a/lua/csvview/sticky_header.lua
+++ b/lua/csvview/sticky_header.lua
@@ -1,3 +1,5 @@
+local win_overlay = require("csvview.win_overlay")
+
 local M = {}
 
 M._sticky_header_wins = {} --- @type table<integer,integer> winid -> sticky-header winid
@@ -14,93 +16,6 @@ local function sync_horizontal_scroll(winid, header_winid, header_lnum)
       vim.fn.winrestview({ topline = header_lnum, lnum = header_lnum, leftcol = win_view.leftcol })
     end
   end)
-end
-
---- Get the 'statuscolumn' option of the window, or the default value if it is empty.
----@param winid integer window ID
----@return string
-local function get_statuscolumn_or_default(winid)
-  local statuscolumn = vim.api.nvim_get_option_value("statuscolumn", { win = winid, scope = "local" }) ---@type string
-  if statuscolumn ~= "" then
-    return statuscolumn
-  end
-
-  -- default
-  if vim.fn.has("nvim-0.11") ~= 1 then
-    -- below neovim 0.11
-    -- https://github.com/neovim/neovim/pull/29357
-    local relnum = vim.api.nvim_get_option_value("relativenumber", { win = winid, scope = "local" }) ---@type boolean
-    return relnum and "%C%=%s%=%r " or "%C%=%s%=%l "
-  end
-
-  local num = vim.api.nvim_get_option_value("number", { win = winid, scope = "local" }) ---@type boolean
-  local trailing_space = num and " " or ""
-  return "%C%=%s%=%l" .. trailing_space
-end
-
---- Convert the dictionary returned by nvim_eval_statusline() into a
---- 'statuscolumn'-compatible string that reproduces the highlights.
---- @param eval_result { str: string, width: number, highlights: {start: number, group:string, groups: string[] }[] } A dictionary from nvim_eval_statusline()
---- @return string converted A string in 'statuscolumn' format.
-local function format_to_stc_string(eval_result)
-  local text = eval_result.str or ""
-  local highlights = eval_result.highlights
-  if not highlights or #highlights == 0 then
-    return text
-  end
-
-  local pieces = {}
-  for i, hl in ipairs(highlights) do
-    local start_index = hl.start
-    local end_index = (i < #highlights) and highlights[i + 1].start or #text
-    -- Extract the string corresponding to the current segment
-    local segment = string.sub(text, start_index + 1, end_index)
-
-    -- Use the last highlight group
-    local groups = hl.groups or { hl.group } -- fallback to hl.group for compatibility
-    local group_name = #groups > 0 and groups[#groups] or "Normal"
-
-    -- %#…# to start highlight, %* to end highlight
-    table.insert(pieces, "%#" .. group_name .. "#" .. segment .. "%*")
-  end
-
-  return table.concat(pieces)
-end
-
---- Copy window options from one window to another
---- @param names string[]: List of option names to copy
---- @param source integer: Source window ID
---- @param target integer: Target window ID
-local function copy_win_options(names, source, target)
-  for _, name in ipairs(names) do
-    local value = vim.api.nvim_get_option_value(name, { win = source, scope = "local" })
-    vim.api.nvim_set_option_value(name, value, { win = target, scope = "local" })
-  end
-end
-
---- Set window options for the sticky header window
----@param sticky_header_winid integer
----@param winid integer
-local function set_sticky_header_win_options(sticky_header_winid, winid)
-  local opts = { ---@type vim.api.keyset.option
-    win = sticky_header_winid,
-    scope = "local",
-  }
-
-  -- Set special statuscolumn for sticky header window
-  local statuscolumn = string.format("%%{%%v:lua.require('csvview.sticky_header').statuscolumn(%d)%%}", winid)
-  vim.api.nvim_set_option_value("statuscolumn", statuscolumn, opts)
-
-  -- use Normal instead of NormalFloat
-  vim.api.nvim_set_option_value("winhighlight", "NormalFloat:Normal", opts)
-
-  -- Copy window options from the main window to the sticky header window
-  copy_win_options({
-    "relativenumber",
-    "signcolumn",
-    "foldcolumn",
-    "numberwidth",
-  }, winid, sticky_header_winid)
 end
 
 --- Get the border characters for the sticky header window.
@@ -154,7 +69,7 @@ local function show_sticky_header(winid, view)
   vim.w[sticky_header_winid].csvview_sticky_header_win = true
 
   -- Set window options
-  set_sticky_header_win_options(sticky_header_winid, winid)
+  win_overlay.setup_overlay_win_options(sticky_header_winid, winid)
 end
 
 --- Determine if the sticky header should be shown.
@@ -190,24 +105,6 @@ local function should_show_sticky_header(winid, view)
   return true
 end
 
---- Get the CsvView.View that is displayed in the window.
----@param winid integer window ID
----@return CsvView.View? view
-local function get_opened_csvview(winid)
-  if not vim.api.nvim_win_is_valid(winid) then
-    return
-  end
-
-  -- sticky header window
-  if vim.w[winid].csvview_sticky_header_win then
-    return
-  end
-
-  local bufnr = vim.api.nvim_win_get_buf(winid)
-  local view = require("csvview.view").get(bufnr)
-  return view
-end
-
 --- Close header window
 ---@param winid integer
 function M.close_header_win_for(winid)
@@ -229,33 +126,11 @@ function M.close_header_win_for(winid)
   end)
 end
 
---- statuscolumn function for sticky header window.
----@param winid integer csvview attached window
----@return string statuscolumn
-function M.statuscolumn(winid)
-  if not vim.api.nvim_win_is_valid(winid) then
-    return ""
-  end
-
-  -- Evaluate the status column in the original window and reflect the result in the sticky header window.
-  -- This allows correct display of things like relativenumber.
-  local statuscolumn = get_statuscolumn_or_default(winid)
-  local data = vim.api.nvim_eval_statusline(statuscolumn, {
-    use_statuscol_lnum = vim.v.lnum,
-    winid = winid,
-    highlights = true,
-    fillchar = " ",
-  })
-
-  ---@diagnostic disable-next-line: param-type-mismatch
-  return format_to_stc_string(data)
-end
-
 --- Redraw all sticky headers
 function M.redraw()
   local wins = vim.api.nvim_tabpage_list_wins(0)
   for _, winid in ipairs(wins) do
-    local view = get_opened_csvview(winid)
+    local view = win_overlay.get_opened_csvview(winid)
     if view and should_show_sticky_header(winid, view) then
       show_sticky_header(winid, view)
       sync_horizontal_scroll(winid, M._sticky_header_wins[winid], view.header_lnum)

--- a/lua/csvview/view.lua
+++ b/lua/csvview/view.lua
@@ -94,6 +94,45 @@ function View:render_lines(top_lnum, bot_lnum)
   end
 end
 
+--- Display width of the first `count` columns, delimiters included.
+---
+--- Mirrors the padding rules of `_render_field`: each column occupies its width
+--- plus the configured spacing, and every column is followed by a delimiter.
+--- Returns nil while the metrics for those columns are still being computed.
+---@param count integer number of columns, counted from the left
+---@return integer? width
+function View:pinned_width(count)
+  local delimiter = (vim.b[self.bufnr].csvview_info or {}).delimiter ---@type { text: string }?
+  if not delimiter then
+    return nil
+  end
+
+  -- In border mode the delimiter is concealed by a single-cell border char.
+  local delimiter_width = self.opts.view.display_mode == "border" and 1 or vim.fn.strdisplaywidth(delimiter.text)
+
+  local spacing = self.opts.view.spacing
+  local width = 0
+  for column_index = 1, count do
+    local column = self.metrics:column(column_index)
+    if not column then
+      return nil -- not computed yet, or fewer columns than requested
+    end
+
+    local left, right ---@type integer, integer
+    if type(spacing) == "table" then
+      left = column_index == 1 and 0 or (spacing.left or 0)
+      right = spacing.right or 0
+    else
+      -- A number adds the same total spacing regardless of align direction.
+      left, right = 0, spacing
+    end
+
+    width = width + math.max(column.max_width, self.opts.view.min_column_width) + left + right + delimiter_width
+  end
+
+  return width
+end
+
 --- Setup window options
 --- @param winid integer
 function View:setup_window(winid)

--- a/lua/csvview/win_overlay.lua
+++ b/lua/csvview/win_overlay.lua
@@ -1,0 +1,133 @@
+--- Helpers shared by the floating windows that overlay a csvview window
+--- (`sticky_header`, `sticky_columns`).
+local M = {}
+
+--- Get the 'statuscolumn' option of the window, or the default value if it is empty.
+---@param winid integer window ID
+---@return string
+local function get_statuscolumn_or_default(winid)
+  local statuscolumn = vim.api.nvim_get_option_value("statuscolumn", { win = winid, scope = "local" }) ---@type string
+  if statuscolumn ~= "" then
+    return statuscolumn
+  end
+
+  -- default
+  if vim.fn.has("nvim-0.11") ~= 1 then
+    -- below neovim 0.11
+    -- https://github.com/neovim/neovim/pull/29357
+    local relnum = vim.api.nvim_get_option_value("relativenumber", { win = winid, scope = "local" }) ---@type boolean
+    return relnum and "%C%=%s%=%r " or "%C%=%s%=%l "
+  end
+
+  local num = vim.api.nvim_get_option_value("number", { win = winid, scope = "local" }) ---@type boolean
+  local trailing_space = num and " " or ""
+  return "%C%=%s%=%l" .. trailing_space
+end
+
+--- Convert the dictionary returned by nvim_eval_statusline() into a
+--- 'statuscolumn'-compatible string that reproduces the highlights.
+--- @param eval_result { str: string, width: number, highlights: {start: number, group:string, groups: string[] }[] } A dictionary from nvim_eval_statusline()
+--- @return string converted A string in 'statuscolumn' format.
+local function format_to_stc_string(eval_result)
+  local text = eval_result.str or ""
+  local highlights = eval_result.highlights
+  if not highlights or #highlights == 0 then
+    return text
+  end
+
+  local pieces = {}
+  for i, hl in ipairs(highlights) do
+    local start_index = hl.start
+    local end_index = (i < #highlights) and highlights[i + 1].start or #text
+    -- Extract the string corresponding to the current segment
+    local segment = string.sub(text, start_index + 1, end_index)
+
+    -- Use the last highlight group
+    local groups = hl.groups or { hl.group } -- fallback to hl.group for compatibility
+    local group_name = #groups > 0 and groups[#groups] or "Normal"
+
+    -- %#…# to start highlight, %* to end highlight
+    table.insert(pieces, "%#" .. group_name .. "#" .. segment .. "%*")
+  end
+
+  return table.concat(pieces)
+end
+
+--- Copy window options from one window to another
+--- @param names string[]: List of option names to copy
+--- @param source integer: Source window ID
+--- @param target integer: Target window ID
+function M.copy_win_options(names, source, target)
+  for _, name in ipairs(names) do
+    local value = vim.api.nvim_get_option_value(name, { win = source, scope = "local" })
+    vim.api.nvim_set_option_value(name, value, { win = target, scope = "local" })
+  end
+end
+
+--- statuscolumn function for an overlay window.
+---@param winid integer csvview attached window
+---@return string statuscolumn
+function M.statuscolumn(winid)
+  if not vim.api.nvim_win_is_valid(winid) then
+    return ""
+  end
+
+  -- Evaluate the status column in the original window and reflect the result in the overlay window.
+  -- This allows correct display of things like relativenumber.
+  local statuscolumn = get_statuscolumn_or_default(winid)
+  local data = vim.api.nvim_eval_statusline(statuscolumn, {
+    use_statuscol_lnum = vim.v.lnum,
+    winid = winid,
+    highlights = true,
+    fillchar = " ",
+  })
+
+  ---@diagnostic disable-next-line: param-type-mismatch
+  return format_to_stc_string(data)
+end
+
+--- Mirror the gutter and number-related options of the csvview window onto an overlay window.
+---@param overlay_winid integer
+---@param winid integer csvview attached window
+function M.setup_overlay_win_options(overlay_winid, winid)
+  local opts = { ---@type vim.api.keyset.option
+    win = overlay_winid,
+    scope = "local",
+  }
+
+  -- Set special statuscolumn for the overlay window
+  local statuscolumn = string.format("%%{%%v:lua.require('csvview.win_overlay').statuscolumn(%d)%%}", winid)
+  vim.api.nvim_set_option_value("statuscolumn", statuscolumn, opts)
+
+  -- use Normal instead of NormalFloat
+  vim.api.nvim_set_option_value("winhighlight", "NormalFloat:Normal", opts)
+
+  -- Copy window options from the main window to the overlay window
+  M.copy_win_options({
+    "relativenumber",
+    "signcolumn",
+    "foldcolumn",
+    "numberwidth",
+  }, winid, overlay_winid)
+end
+
+--- Get the CsvView.View displayed in the window, if any.
+---
+--- Returns nil for windows that are themselves csvview overlays.
+---@param winid integer window ID
+---@return CsvView.View? view
+function M.get_opened_csvview(winid)
+  if not vim.api.nvim_win_is_valid(winid) then
+    return
+  end
+
+  -- overlay window
+  if vim.w[winid].csvview_sticky_header_win or vim.w[winid].csvview_sticky_columns_win then
+    return
+  end
+
+  local bufnr = vim.api.nvim_win_get_buf(winid)
+  return require("csvview.view").get(bufnr)
+end
+
+return M

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -89,18 +89,6 @@ end, {
   end,
 })
 
-vim.api.nvim_create_user_command("CsvViewUpdate", function(opts)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local cmdopts = cmdline:parse(opts.args, create_empty_opts())
-  csvview.update(bufnr, cmdopts)
-end, {
-  desc = "[csvview] Change options of an enabled buffer",
-  nargs = "?",
-  complete = function(arg_lead, cmd_line, cursor_pos)
-    return cmdline:complete(arg_lead, cmd_line, cursor_pos)
-  end,
-})
-
 vim.api.nvim_create_user_command("CsvViewDisable", function()
   csvview.disable()
 end, {

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -101,19 +101,6 @@ end, {
   end,
 })
 
-vim.api.nvim_create_user_command("CsvViewStickyColumns", function(opts)
-  local count = tonumber(opts.args) or 1
-  csvview.update(vim.api.nvim_get_current_buf(), {
-    view = { sticky_columns = { enabled = count >= 1, count = math.max(count, 1) } },
-  })
-end, {
-  desc = "[csvview] Pin the leftmost N columns (0 to unpin)",
-  nargs = "?",
-  complete = function()
-    return { "0", "1", "2", "3" }
-  end,
-})
-
 vim.api.nvim_create_user_command("CsvViewDisable", function()
   csvview.disable()
 end, {

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -89,9 +89,23 @@ end, {
   end,
 })
 
+vim.api.nvim_create_user_command("CsvViewUpdate", function(opts)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local cmdopts = cmdline:parse(opts.args, create_empty_opts())
+  csvview.update(bufnr, cmdopts)
+end, {
+  desc = "[csvview] Change options of an enabled buffer",
+  nargs = "?",
+  complete = function(arg_lead, cmd_line, cursor_pos)
+    return cmdline:complete(arg_lead, cmd_line, cursor_pos)
+  end,
+})
+
 vim.api.nvim_create_user_command("CsvViewStickyColumns", function(opts)
   local count = tonumber(opts.args) or 1
-  csvview.set_sticky_columns(vim.api.nvim_get_current_buf(), count)
+  csvview.update(vim.api.nvim_get_current_buf(), {
+    view = { sticky_columns = { enabled = count >= 1, count = math.max(count, 1) } },
+  })
 end, {
   desc = "[csvview] Pin the leftmost N columns (0 to unpin)",
   nargs = "?",

--- a/plugin/csvview.lua
+++ b/plugin/csvview.lua
@@ -58,6 +58,16 @@ local cmdline = Cmdline:new({
     end,
     candidates = { "none", "auto", "" },
   },
+  {
+    name = "sticky_columns",
+    ---@param options CsvView.Options
+    ---@param value string
+    set = function(options, value)
+      local count = tonumber(value) or 0
+      options.view.sticky_columns = { enabled = count >= 1, count = math.max(count, 1) }
+    end,
+    candidates = { "0", "1", "2", "3" },
+  },
 })
 
 local function create_empty_opts()
@@ -76,6 +86,17 @@ end, {
   nargs = "?",
   complete = function(arg_lead, cmd_line, cursor_pos)
     return cmdline:complete(arg_lead, cmd_line, cursor_pos)
+  end,
+})
+
+vim.api.nvim_create_user_command("CsvViewStickyColumns", function(opts)
+  local count = tonumber(opts.args) or 1
+  csvview.set_sticky_columns(vim.api.nvim_get_current_buf(), count)
+end, {
+  desc = "[csvview] Pin the leftmost N columns (0 to unpin)",
+  nargs = "?",
+  complete = function()
+    return { "0", "1", "2", "3" }
   end,
 })
 

--- a/tests/csvview_spec.lua
+++ b/tests/csvview_spec.lua
@@ -97,4 +97,69 @@ describe("csvview", function()
   end
   run_update_tests(require("tests.cases.buffer_update"))
   run_update_tests(require("tests.cases.buffer_update_multiline"))
+
+  describe("update", function()
+    config.setup()
+    csvview.setup()
+
+    --- Enable csvview on a fresh buffer and return it.
+    ---@param opts CsvView.Options?
+    ---@return integer bufnr
+    local function enabled_buf(opts)
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
+        "name,age,city",
+        "John,25,New York",
+        "Jane,30,Los Angeles",
+      })
+      vim.api.nvim_win_set_buf(vim.api.nvim_get_current_win(), bufnr)
+      csvview.enable(bufnr, opts)
+      vim.wait(50)
+      return bufnr
+    end
+
+    it("should apply view options to the attached view", function()
+      local bufnr = enabled_buf({ view = { display_mode = "highlight" } })
+      csvview.update(bufnr, { view = { display_mode = "border" } })
+      vim.wait(50)
+
+      local view = require("csvview.view").get(bufnr)
+      assert(view)
+      assert.equals("border", view.opts.view.display_mode)
+      assert.equals(2, vim.api.nvim_get_option_value("conceallevel", { win = 0, scope = "local" }))
+
+      csvview.disable(bufnr)
+    end)
+
+    it("should re-parse when a parser option changes", function()
+      local bufnr = enabled_buf({ parser = { delimiter = "," } })
+      csvview.update(bufnr, { parser = { delimiter = ";" } })
+      vim.wait(50)
+
+      assert.is_true(csvview.is_enabled(bufnr))
+      assert.equals(";", vim.b[bufnr].csvview_info.delimiter.text)
+
+      -- The whole line is one field with the new delimiter.
+      local view = require("csvview.view").get(bufnr)
+      assert(view)
+      assert.equals(1, view.metrics:row({ lnum = 1 }):field_count())
+
+      csvview.disable(bufnr)
+    end)
+
+    it("should warn and do nothing when the buffer is not enabled", function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local notified = false
+      local notify = vim.notify
+      vim.notify = function() ---@diagnostic disable-line: duplicate-set-field
+        notified = true
+      end
+
+      csvview.update(bufnr, { view = { display_mode = "border" } })
+      vim.notify = notify ---@diagnostic disable-line: duplicate-set-field
+
+      assert.is_true(notified)
+      assert.is_false(csvview.is_enabled(bufnr))
+    end)
+  end)
 end)

--- a/tests/csvview_spec.lua
+++ b/tests/csvview_spec.lua
@@ -98,7 +98,7 @@ describe("csvview", function()
   run_update_tests(require("tests.cases.buffer_update"))
   run_update_tests(require("tests.cases.buffer_update_multiline"))
 
-  describe("update", function()
+  describe("enable on an attached buffer", function()
     config.setup()
     csvview.setup()
 
@@ -120,7 +120,7 @@ describe("csvview", function()
 
     it("should apply view options to the attached view", function()
       local bufnr = enabled_buf({ view = { display_mode = "highlight" } })
-      csvview.update(bufnr, { view = { display_mode = "border" } })
+      csvview.enable(bufnr, { view = { display_mode = "border" } })
       vim.wait(50)
 
       local view = require("csvview.view").get(bufnr)
@@ -133,7 +133,7 @@ describe("csvview", function()
 
     it("should re-parse when a parser option changes", function()
       local bufnr = enabled_buf({ parser = { delimiter = "," } })
-      csvview.update(bufnr, { parser = { delimiter = ";" } })
+      csvview.enable(bufnr, { parser = { delimiter = ";" } })
       vim.wait(50)
 
       assert.is_true(csvview.is_enabled(bufnr))
@@ -147,19 +147,24 @@ describe("csvview", function()
       csvview.disable(bufnr)
     end)
 
-    it("should warn and do nothing when the buffer is not enabled", function()
-      local bufnr = vim.api.nvim_create_buf(false, true)
+    it("should keep the view when enabling again without options", function()
+      local bufnr = enabled_buf()
+      local view = require("csvview.view").get(bufnr)
+
       local notified = false
       local notify = vim.notify
       vim.notify = function() ---@diagnostic disable-line: duplicate-set-field
         notified = true
       end
 
-      csvview.update(bufnr, { view = { display_mode = "border" } })
+      csvview.enable(bufnr)
+      vim.wait(50)
       vim.notify = notify ---@diagnostic disable-line: duplicate-set-field
 
-      assert.is_true(notified)
-      assert.is_false(csvview.is_enabled(bufnr))
+      assert.is_false(notified)
+      assert.are.equal(view, require("csvview.view").get(bufnr))
+
+      csvview.disable(bufnr)
     end)
   end)
 end)

--- a/tests/sticky_columns_spec.lua
+++ b/tests/sticky_columns_spec.lua
@@ -164,14 +164,14 @@ describe("sticky_columns", function()
     assert.are.equal(3, vim.api.nvim_get_option_value("sidescrolloff", { win = winid, scope = "local" }))
   end)
 
-  it("CsvViewStickyColumns retunes an attached view", function()
+  it("CsvViewUpdate retunes an attached view", function()
     vim.cmd("runtime! plugin/csvview.lua") -- tests run with --noplugin
     local bufnr = vim.api.nvim_get_current_buf()
     csvview.enable(bufnr, { view = { sticky_columns = { enabled = false, count = 1 } } })
     vim.wait(50)
 
     vim.fn.winrestview({ topline = 10, lnum = 15, leftcol = 40, col = 60 })
-    vim.cmd("CsvViewStickyColumns 2")
+    vim.cmd("CsvViewUpdate sticky_columns=2")
     vim.wait(20)
     should_show_sticky_columns()
 
@@ -179,7 +179,7 @@ describe("sticky_columns", function()
     assert(view)
     assert.are.equal(2, view.opts.view.sticky_columns.count)
 
-    vim.cmd("CsvViewStickyColumns 0")
+    vim.cmd("CsvViewUpdate sticky_columns=0")
     vim.wait(20)
     should_not_show_sticky_columns()
 

--- a/tests/sticky_columns_spec.lua
+++ b/tests/sticky_columns_spec.lua
@@ -55,13 +55,6 @@ describe("sticky_columns", function()
       assert = should_show_sticky_columns,
     },
     {
-      name = "hides when the cursor is inside the pinned region",
-      winview = { topline = 10, lnum = 15, leftcol = 20, col = 20 },
-      winopts = { { "sidescrolloff", 0 }, { "scrolloff", 0 } },
-      opts = { view = { sticky_columns = { enabled = true, count = 1 } } },
-      assert = should_not_show_sticky_columns,
-    },
-    {
       name = "syncs with the current window vertical scroll and pins leftcol at 0",
       winview = { topline = 10, lnum = 15, leftcol = 20, col = 40 },
       winopts = { { "sidescrolloff", 0 }, { "scrolloff", 0 } },
@@ -131,6 +124,26 @@ describe("sticky_columns", function()
       vim.api.nvim_set_option_value(opt[1], nil, { win = winid, scope = "local" })
     end
   end
+
+  it("reserves and restores 'sidescrolloff'", function()
+    local winid = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_option_value("sidescrolloff", 3, { win = winid, scope = "local" })
+
+    local bufnr = vim.api.nvim_get_current_buf()
+    csvview.enable(bufnr, { view = { sticky_columns = { enabled = true, count = 1 } } })
+    vim.wait(50)
+    require("csvview.sticky_columns").redraw()
+    vim.wait(20)
+
+    local view = require("csvview.view").get(bufnr)
+    assert(view)
+    local expected = view:pinned_width(1) + 1
+    assert.are.equal(expected, vim.api.nvim_get_option_value("sidescrolloff", { win = winid, scope = "local" }))
+
+    csvview.disable(bufnr)
+    vim.wait(20)
+    assert.are.equal(3, vim.api.nvim_get_option_value("sidescrolloff", { win = winid, scope = "local" }))
+  end)
 
   it("CsvViewStickyColumns retunes an attached view", function()
     vim.cmd("runtime! plugin/csvview.lua") -- tests run with --noplugin

--- a/tests/sticky_columns_spec.lua
+++ b/tests/sticky_columns_spec.lua
@@ -164,14 +164,14 @@ describe("sticky_columns", function()
     assert.are.equal(3, vim.api.nvim_get_option_value("sidescrolloff", { win = winid, scope = "local" }))
   end)
 
-  it("CsvViewUpdate retunes an attached view", function()
+  it("CsvViewEnable retunes an attached view", function()
     vim.cmd("runtime! plugin/csvview.lua") -- tests run with --noplugin
     local bufnr = vim.api.nvim_get_current_buf()
     csvview.enable(bufnr, { view = { sticky_columns = { enabled = false, count = 1 } } })
     vim.wait(50)
 
     vim.fn.winrestview({ topline = 10, lnum = 15, leftcol = 40, col = 60 })
-    vim.cmd("CsvViewUpdate sticky_columns=2")
+    vim.cmd("CsvViewEnable sticky_columns=2")
     vim.wait(20)
     should_show_sticky_columns()
 
@@ -179,7 +179,7 @@ describe("sticky_columns", function()
     assert(view)
     assert.are.equal(2, view.opts.view.sticky_columns.count)
 
-    vim.cmd("CsvViewUpdate sticky_columns=0")
+    vim.cmd("CsvViewEnable sticky_columns=0")
     vim.wait(20)
     should_not_show_sticky_columns()
 

--- a/tests/sticky_columns_spec.lua
+++ b/tests/sticky_columns_spec.lua
@@ -1,0 +1,156 @@
+---@diagnostic disable: await-in-sync
+local config = require("csvview.config")
+local csvview = require("csvview")
+
+---@class CsvView.Tests.StickyColumnsCase
+---@field name string
+---@field winview vim.fn.winrestview.dict
+---@field winopts? { [1]: string, [2]: any }[]
+---@field opts CsvView.Options
+---@field assert fun(case: CsvView.Tests.StickyColumnsCase)
+
+local function get_sticky_columns_win()
+  for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.w[winid].csvview_sticky_columns_win then
+      return winid
+    end
+  end
+
+  return nil
+end
+
+local function should_show_sticky_columns()
+  assert.are.not_nil(get_sticky_columns_win(), "Sticky columns window should be opened")
+end
+
+local function should_not_show_sticky_columns()
+  assert.are_nil(get_sticky_columns_win(), "Sticky columns window should not be opened")
+end
+
+describe("sticky_columns", function()
+  before_each(function()
+    config.setup()
+    csvview.setup()
+  end)
+
+  ---@type CsvView.Tests.StickyColumnsCase[]
+  local cases = {
+    {
+      name = "does not show when the sticky_columns option is disabled",
+      winview = { topline = 10, lnum = 15, leftcol = 20, col = 40 },
+      opts = { view = { sticky_columns = { enabled = false, count = 1 } } },
+      assert = should_not_show_sticky_columns,
+    },
+    {
+      name = "does not show when nothing is scrolled out of view",
+      winview = { topline = 10, lnum = 15, leftcol = 0, col = 0 },
+      opts = { view = { sticky_columns = { enabled = true, count = 1 } } },
+      assert = should_not_show_sticky_columns,
+    },
+    {
+      name = "shows when the window is scrolled horizontally",
+      winview = { topline = 10, lnum = 15, leftcol = 20, col = 40 },
+      winopts = { { "sidescrolloff", 0 }, { "scrolloff", 0 } },
+      opts = { view = { sticky_columns = { enabled = true, count = 1 } } },
+      assert = should_show_sticky_columns,
+    },
+    {
+      name = "hides when the cursor is inside the pinned region",
+      winview = { topline = 10, lnum = 15, leftcol = 20, col = 20 },
+      winopts = { { "sidescrolloff", 0 }, { "scrolloff", 0 } },
+      opts = { view = { sticky_columns = { enabled = true, count = 1 } } },
+      assert = should_not_show_sticky_columns,
+    },
+    {
+      name = "syncs with the current window vertical scroll and pins leftcol at 0",
+      winview = { topline = 10, lnum = 15, leftcol = 20, col = 40 },
+      winopts = { { "sidescrolloff", 0 }, { "scrolloff", 0 } },
+      opts = { view = { sticky_columns = { enabled = true, count = 1 } } },
+      assert = function(case)
+        local winid = get_sticky_columns_win()
+        assert.are.not_nil(winid)
+        assert(winid) -- suppress luals check
+
+        local winview = vim.api.nvim_win_call(winid, vim.fn.winsaveview) ---@type vim.fn.winsaveview.ret
+        assert.are.equal(case.winview.topline, winview.topline)
+        assert.are.equal(0, winview.leftcol)
+      end,
+    },
+    {
+      name = "widens the overlay for more pinned columns",
+      winview = { topline = 10, lnum = 15, leftcol = 40, col = 60 },
+      winopts = { { "sidescrolloff", 0 }, { "scrolloff", 0 } },
+      opts = { view = { sticky_columns = { enabled = true, count = 2 } } },
+      assert = function()
+        local winid = get_sticky_columns_win()
+        assert.are.not_nil(winid)
+        assert(winid) -- suppress luals check
+
+        local view = require("csvview.view").get(vim.api.nvim_get_current_buf())
+        assert.are.not_nil(view)
+        assert(view) -- suppress luals check
+
+        assert.are.equal(view:pinned_width(2), vim.api.nvim_win_get_width(winid))
+        assert.is_true(view:pinned_width(2) > view:pinned_width(1))
+      end,
+    },
+  }
+
+  vim.cmd.edit("tests/fixtures/test.csv")
+  for _, case in ipairs(cases) do
+    if csvview.is_enabled(0) then
+      csvview.disable(0)
+    end
+
+    -- Set the window options
+    local winid = vim.api.nvim_get_current_win()
+    for _, opt in ipairs(case.winopts or {}) do
+      vim.api.nvim_set_option_value(opt[1], opt[2], { win = winid, scope = "local" })
+    end
+
+    it(case.name, function()
+      -- Enable csvview first: the pinned width depends on the computed metrics.
+      local bufnr = vim.api.nvim_get_current_buf()
+      csvview.enable(bufnr, case.opts)
+      vim.wait(50)
+
+      vim.fn.winrestview(case.winview)
+      vim.wait(1)
+      require("csvview.sticky_columns").redraw()
+      vim.wait(20) -- overlay windows are closed on the scheduler
+
+      case.assert(case)
+
+      -- Cleanup
+      csvview.disable(bufnr)
+      vim.wait(20)
+    end)
+
+    -- Clear window options
+    for _, opt in ipairs(case.winopts or {}) do
+      vim.api.nvim_set_option_value(opt[1], nil, { win = winid, scope = "local" })
+    end
+  end
+
+  it("CsvViewStickyColumns retunes an attached view", function()
+    vim.cmd("runtime! plugin/csvview.lua") -- tests run with --noplugin
+    local bufnr = vim.api.nvim_get_current_buf()
+    csvview.enable(bufnr, { view = { sticky_columns = { enabled = false, count = 1 } } })
+    vim.wait(50)
+
+    vim.fn.winrestview({ topline = 10, lnum = 15, leftcol = 40, col = 60 })
+    vim.cmd("CsvViewStickyColumns 2")
+    vim.wait(20)
+    should_show_sticky_columns()
+
+    local view = require("csvview.view").get(bufnr)
+    assert(view)
+    assert.are.equal(2, view.opts.view.sticky_columns.count)
+
+    vim.cmd("CsvViewStickyColumns 0")
+    vim.wait(20)
+    should_not_show_sticky_columns()
+
+    csvview.disable(bufnr)
+  end)
+end)

--- a/tests/sticky_columns_spec.lua
+++ b/tests/sticky_columns_spec.lua
@@ -126,6 +126,24 @@ describe("sticky_columns", function()
     end
   end
 
+  it("draws a separator at the right edge when configured", function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    csvview.enable(bufnr, { view = { sticky_columns = { enabled = true, count = 1, separator = "." } } })
+    vim.wait(50)
+
+    vim.fn.winrestview({ topline = 10, lnum = 15, leftcol = 40, col = 60 })
+    require("csvview.sticky_columns").redraw()
+    vim.wait(20)
+
+    local winid = get_sticky_columns_win()
+    assert(winid)
+    local border = vim.api.nvim_win_get_config(winid).border
+    assert.are.same({ ".", "CsvViewStickyColumnsSeparator" }, border[4])
+
+    csvview.disable(bufnr)
+    vim.wait(20)
+  end)
+
   it("reserves and restores 'sidescrolloff'", function()
     local winid = vim.api.nvim_get_current_win()
     vim.api.nvim_set_option_value("sidescrolloff", 3, { win = winid, scope = "local" })

--- a/tests/sticky_columns_spec.lua
+++ b/tests/sticky_columns_spec.lua
@@ -9,9 +9,10 @@ local csvview = require("csvview")
 ---@field opts CsvView.Options
 ---@field assert fun(case: CsvView.Tests.StickyColumnsCase)
 
-local function get_sticky_columns_win()
+---@param role? "columns"|"corner"
+local function get_sticky_columns_win(role)
   for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
-    if vim.w[winid].csvview_sticky_columns_win then
+    if vim.w[winid].csvview_sticky_columns_win == (role or "columns") then
       return winid
     end
   end


### PR DESCRIPTION
## Summary

Adds sticky columns (#78). The first N columns stay pinned while scrolling horizontally, like frozen panes in a spreadsheet.

<!-- demo gif goes here -->

```lua
require("csvview").setup({
  view = {
    sticky_columns = {
      enabled = true,
      count = 2,
    },
  },
})
```

It can also be set from the command line:

```
:CsvViewEnable sticky_columns=2
```

## Changes

- New `view.sticky_columns` option with `enabled`, `count` and `separator` settings
- Pinned columns are drawn with a floating window overlay, same approach as the sticky header
- Moved the shared overlay logic from `sticky_header.lua` into a new `win_overlay.lua` so both features use it
- Optional separator character at the right edge of the pinned columns, off by default since border mode already draws one
- Works together with the sticky header, the header cells stay pinned too
- Calling enable again updates the options, so `:CsvViewEnable sticky_columns=3` changes the count on the fly
- Tests in `tests/sticky_columns_spec.lua`, docs in README and GUIDE
